### PR TITLE
Allow rotation of Session::consume targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,6 +158,7 @@ endfunction()
 add_example(HelloWorld)
 add_example(DetailedHelloWorld)
 add_example(ConsumeLoop)
+add_example(LogRotation)
 
 #---------------------------
 # Unit Test

--- a/doc/UserGuide.md
+++ b/doc/UserGuide.md
@@ -278,3 +278,15 @@ estimated amount of data one iteration produces:
 
 For different kind of applications, calling `consume` periodically in a dedicated thread
 or task can be an option.
+
+# Log Rotation
+
+[Log rotation][] can be achieved by simply changing the output stream passed to `Session::consume`.
+`Session` does not know or care about the underlying device of the stream.
+However, metadata is not added automatically to the new file (as `Session` does not know
+that a rotation happened). To make the new file self contained (i.e: readable without the
+metadata in the old file), old metadata has to be added via `Session::reconsumeMetadata`:
+
+    [catchfile example/LogRotation.cpp rotate]
+
+[Log rotation]: https://en.wikipedia.org/wiki/Log_rotation

--- a/example/LogRotation.cpp
+++ b/example/LogRotation.cpp
@@ -1,0 +1,48 @@
+#include <binlog/binlog.hpp>
+
+#include <cstdio> // rename
+#include <fstream>
+#include <iostream>
+
+int main()
+{
+  // log to rotate.blog
+  BINLOG_INFO("Hello, first file");
+  std::ofstream logfile("rotate.blog", std::ofstream::out|std::ofstream::binary);
+  binlog::consume(logfile);
+
+  if (! logfile)
+  {
+    std::cerr << "Failed to write rotate.blog\n";
+    return 1;
+  }
+
+  //[rotate
+  if (std::rename("rotate.blog", "rotate.1.blog") != 0)
+  {
+    std::cerr << "Failed to rename rotate.blog to rotate.1.blog\n";
+    return 2;
+  }
+
+  logfile.close();
+  logfile.open("rotate.blog", std::ofstream::out|std::ofstream::binary);
+
+  // Metadata is now moved to rotate.1.blog, rotate.blog is empty.
+  // To make rotate.blog stand alone, re-add metadata:
+  binlog::default_session().reconsumeMetadata(logfile);
+  //]
+
+  // log to rotate.blog - a new file with the old name
+  BINLOG_INFO("Hello, second file");
+  binlog::consume(logfile);
+
+  if (! logfile)
+  {
+    std::cerr << "Failed to write rotate.blog after rotation\n";
+    return 3;
+  }
+
+  std::cout << "Binary log written to rotate.blog and rotate.1.blog\n";
+
+  return 0;
+}

--- a/include/binlog/Session.hpp
+++ b/include/binlog/Session.hpp
@@ -153,6 +153,7 @@ private:
 
   std::list<Channel> _channels;
   std::deque<EventSource> _sources;
+  std::size_t _numConsumedSources = 0;
   std::uint64_t _nextSourceId = 1;
 
   std::size_t _totalConsumedBytes = 0;
@@ -232,11 +233,10 @@ Session::ConsumeResult Session::consume(OutputStream& out)
   }
 
   // consume event sources before events
-  for (const EventSource& eventSource : _sources)
+  for (; _numConsumedSources < _sources.size(); ++_numConsumedSources)
   {
-    result.bytesConsumed += serializeSizePrefixedTagged(eventSource, out);
+    result.bytesConsumed += serializeSizePrefixedTagged(_sources[_numConsumedSources], out);
   }
-  _sources = {}; // consumed sources are no longer needed, release memory
 
   // consume some events
   for (auto it = _channels.begin(); it != _channels.end();)

--- a/test/unit/binlog/TestSession.cpp
+++ b/test/unit/binlog/TestSession.cpp
@@ -1,5 +1,7 @@
 #include <binlog/Session.hpp>
 
+#include <binlog/Entries.hpp>
+
 #include <boost/test/unit_test.hpp>
 
 #include <ios> // streamsize
@@ -70,6 +72,20 @@ BOOST_AUTO_TEST_CASE(min_severity)
   BOOST_TEST((session.minSeverity() == binlog::Severity::info));
 }
 
-// addEventSource and consume are tested in TestSessionWriter.cpp
+BOOST_AUTO_TEST_CASE(sources_consumed_once)
+{
+  binlog::Session session;
+  binlog::EventSource eventSource;
+  session.addEventSource(eventSource);
+
+  NullOstream out;
+  binlog::Session::ConsumeResult cr = session.consume(out);
+  BOOST_TEST(cr.bytesConsumed != 0);
+
+  cr = session.consume(out);
+  BOOST_TEST(cr.bytesConsumed == 0);
+}
+
+// addEventSource and consume are further tested in TestSessionWriter.cpp
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Add `Session::reconsumeMetadata`, which adds already consumed metadata to the given ostream. This allows the client to replace the ostream used for consume. See the example for usage.

Fixes #3 .