### PR TITLE
Add -s switch to bread to sort events by time (approximate solution)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,6 +135,7 @@ add_library(binlog OBJECT
 
 add_executable(bread
   bin/bread.cpp
+  bin/printers.cpp
   $<TARGET_OBJECTS:binlog>
   $<$<CXX_COMPILER_ID:MSVC>:bin/getopt.cpp bin/binaryio.cpp>
 )
@@ -191,6 +192,9 @@ if(Boost_FOUND)
     test/unit/binlog/TestArrayView.cpp
     test/unit/binlog/TestConstCharPtrIsString.cpp
 
+    bin/printers.cpp
+    test/unit/binlog/TestPrinters.cpp
+
     test/unit/binlog/test_utils.cpp
   )
     target_compile_definitions(UnitTest PRIVATE
@@ -201,6 +205,7 @@ if(Boost_FOUND)
     link_boost(UnitTest unit_test_framework)
     target_link_libraries(UnitTest headers)
     target_link_libraries(UnitTest Threads::Threads) # used by: TestQueue, TestSessionWriter, TestCreateSourceAndEvent
+    target_include_directories(UnitTest PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/bin)
 
   add_test(NAME UnitTest COMMAND UnitTest --log_level=test_suite --color_output=true)
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,10 @@ There's a lot of **redundancy** (the severity, the format string, the file path 
 **wasted space** (the timestamp is represented using 29 bytes, where 8 bytes of information would be plenty),
 and **loss of precision** (the originally computed floating point _result_ is lost, only its text representation
 remains). Furthermore, the log was **expensive to produce** (consider the string conversion of each timestamp
-and float value) and **not trivial to parse** using automated tools.
+and float value) and **not trivial to parse** using automated tools. Conventional log solutions also have to
+make a trade-off: either implement synchronous logging (possibly via slow locking) that ensures the
+log events are sorted by creation time, or asynchronous logging (without global locks) that usually
+produces **unsorted output**.
 
 Binlog solves these issues by using _structured binary logs_.
 The static parts (severity, format string, file and line, etc) are saved only once to the logfile.
@@ -38,6 +41,7 @@ without reverting to fragile text processing methods.
 
 _Binary logfiles_ are not human readable, but they can be converted to text using the `bread` program.
 The format of the text log is configurable, independent of the logfile.
+`bread` can also efficiently sort the logs by time, taking advantage of its structured nature.
 For further information, please refer to the [Documentation][].
 
 ## Features
@@ -55,6 +59,7 @@ For further information, please refer to the [Documentation][].
  - Format strings with `{}` placeholders
  - Vertical separation of logs via custom categories
  - Horizontal separation of logs via runtime configurable severities
+ - Sort logs by time while reading
 
 ## Performance
 

--- a/bin/bread.cpp
+++ b/bin/bread.cpp
@@ -1,8 +1,5 @@
 #include "getopt.hpp"
-
-#include <binlog/Entries.hpp> // Event
-#include <binlog/EventStream.hpp>
-#include <binlog/PrettyPrinter.hpp>
+#include "printers.hpp"
 
 #include <fstream>
 #include <iostream>
@@ -19,17 +16,6 @@ std::istream& openFile(const std::string& path, std::ifstream& file)
 
   file.open(path, std::ios_base::in | std::ios_base::binary);
   return file;
-}
-
-void printEvents(std::istream& input, std::ostream& output, const std::string& format, const std::string& dateFormat)
-{
-  binlog::EventStream eventStream(input);
-  binlog::PrettyPrinter pp(format, dateFormat);
-
-  while (const binlog::Event* event = eventStream.nextEvent())
-  {
-    pp.printEvent(output, *event, eventStream.writerProp(), eventStream.clockSync());
-  }
 }
 
 void showHelp()

--- a/bin/printers.cpp
+++ b/bin/printers.cpp
@@ -1,0 +1,19 @@
+#include "printers.hpp"
+
+#include <binlog/Entries.hpp> // Event
+#include <binlog/EventStream.hpp>
+#include <binlog/PrettyPrinter.hpp>
+
+#include <istream>
+#include <ostream>
+
+void printEvents(std::istream& input, std::ostream& output, const std::string& format, const std::string& dateFormat)
+{
+  binlog::EventStream eventStream(input);
+  binlog::PrettyPrinter pp(format, dateFormat);
+
+  while (const binlog::Event* event = eventStream.nextEvent())
+  {
+    pp.printEvent(output, *event, eventStream.writerProp(), eventStream.clockSync());
+  }
+}

--- a/bin/printers.cpp
+++ b/bin/printers.cpp
@@ -4,8 +4,13 @@
 #include <binlog/EventStream.hpp>
 #include <binlog/PrettyPrinter.hpp>
 
+#include <algorithm>
+#include <cstdint>
 #include <istream>
 #include <ostream>
+#include <sstream>
+#include <utility>
+#include <vector>
 
 void printEvents(std::istream& input, std::ostream& output, const std::string& format, const std::string& dateFormat)
 {
@@ -15,5 +20,68 @@ void printEvents(std::istream& input, std::ostream& output, const std::string& f
   while (const binlog::Event* event = eventStream.nextEvent())
   {
     pp.printEvent(output, *event, eventStream.writerProp(), eventStream.clockSync());
+  }
+}
+
+void printSortedEvents(std::istream& input, std::ostream& output, const std::string& format, const std::string& dateFormat)
+{
+  const std::uint64_t maxClockDiff = 30'000'000'000; // 30s assuming 1/ns clock frequency
+
+  binlog::EventStream eventStream(input);
+  binlog::PrettyPrinter pp(format, dateFormat);
+
+  using Pair = std::pair<std::uint64_t /* clock */, std::string /* pretty printed event */>;
+  std::vector<Pair> buffer;
+  std::ostringstream stream;
+
+  std::uint64_t minClock = std::uint64_t(-1);
+
+  const auto cmpClock = [](const Pair& p1, const Pair& p2) { return p1.first < p2.first; };
+
+  while (const binlog::Event* event = eventStream.nextEvent())
+  {
+    // maintain minClock
+    const std::uint64_t now = event->clockValue;
+    minClock = (std::min)(minClock, now);
+
+    // add new event to the buffer
+    stream.str({}); // reset stream
+    pp.printEvent(stream, *event, eventStream.writerProp(), eventStream.clockSync());
+    buffer.emplace_back(now, stream.str());
+
+    // Assume that there's no pair of events that
+    // a.clockValue + maxClockDiff < b.clockValue
+    // AND `a` comes after `b` in the log.
+    // Given that, we can sort and print some events.
+    // To avoid sorting too few events at a time,
+    // we wait until maxClockDiff*2 elapses,
+    // and then sort a maxClockDiff window.
+    if (minClock + maxClockDiff * 2 < now)
+    {
+      // separate events we'd like to print, only sort them
+      const auto isOld = [&](const Pair& p) { return p.first + maxClockDiff < now; };
+      const auto end = std::stable_partition(buffer.begin(), buffer.end(), isOld);
+
+      std::stable_sort(buffer.begin(), end, cmpClock);
+
+      // print sorted events
+      for (auto it = buffer.begin(); it != end; ++it)
+      {
+        output << it->second;
+      }
+
+      // remove printed events
+      buffer.erase(buffer.begin(), end);
+
+      // re-compute minClock
+      minClock = std::min_element(buffer.begin(), buffer.end(), cmpClock)->first;
+    }
+  }
+
+  // sort and print the remaining events
+  std::stable_sort(buffer.begin(), buffer.end(), cmpClock);
+  for (const Pair& p : buffer)
+  {
+    output << p.second;
   }
 }

--- a/bin/printers.hpp
+++ b/bin/printers.hpp
@@ -13,4 +13,20 @@
  */
 void printEvents(std::istream& input, std::ostream& output, const std::string& format, const std::string& dateFormat);
 
+/**
+ * Print the events in `input` to output, according to
+ * `format` and `dateFormat`, approximately sorted by event clock.
+ *
+ * To allow online usage, and remain efficient for large logfiles,
+ * the sorting is approximated by:
+ *
+ *  - buffer events of a 60 seconds window
+ *  - sort and print the events of the first 30 seconds
+ *  - loop until done, sort and print the remaining buffer
+ *
+ * @see PrettyPrinter on `format` and `dateFormat`.
+ * @throws std::runtime_error if invalid binlog entry found in `input`.
+ */
+void printSortedEvents(std::istream& input, std::ostream& output, const std::string& format, const std::string& dateFormat);
+
 #endif // BINLOG_BIN_PRINTERS_HPP

--- a/bin/printers.hpp
+++ b/bin/printers.hpp
@@ -1,0 +1,16 @@
+#ifndef BINLOG_BIN_PRINTERS_HPP
+#define BINLOG_BIN_PRINTERS_HPP
+
+#include <iosfwd>
+#include <string>
+
+/**
+ * Print the events in `input` to output, according to
+ * `format` and `dateFormat`.
+ *
+ * @see PrettyPrinter on `format` and `dateFormat`.
+ * @throws std::runtime_error if invalid binlog entry found in `input`.
+ */
+void printEvents(std::istream& input, std::ostream& output, const std::string& format, const std::string& dateFormat);
+
+#endif // BINLOG_BIN_PRINTERS_HPP

--- a/doc/UserGuide.md
+++ b/doc/UserGuide.md
@@ -184,6 +184,13 @@ The format of the text representation can be customized using command line switc
 
     $ bread -f "%S [%d] %n %m (%G:%L)" -d "%m/%d %H:%M:%S.%N" logfile.blog
 
+The events of the logfile can be sorted by their timestamp using `-s`.
+The sorting is approximate. It assumes that if event `A` comes before event `B` in the logfile,
+then event `B` is no more than 30 seconds older than event `A`.
+This is to allow online sorting of log streams, and memory efficient sorting of large logfiles.
+
+    $ bread -s logfile.blog
+
 To customize the output and for further options, see the builtin help:
 
     $ bread -h

--- a/test/unit/binlog/TestPrinters.cpp
+++ b/test/unit/binlog/TestPrinters.cpp
@@ -23,6 +23,11 @@ std::vector<std::string> streamToLines(std::istream& input)
   return result;
 }
 
+void logClock(binlog::SessionWriter& writer, std::uint64_t clock)
+{
+  BINLOG_CREATE_SOURCE_AND_EVENT(writer, binlog::Severity::info, main, clock, "{}", clock);
+}
+
 } // namespace
 
 BOOST_AUTO_TEST_SUITE(Printers)
@@ -44,6 +49,48 @@ BOOST_AUTO_TEST_CASE(print_events)
   const std::vector<std::string> expected{
     "INFO Hello World",
     "WARN foobar 123",
+  };
+  BOOST_TEST(streamToLines(txtstream) == expected, boost::test_tools::per_element());
+}
+
+BOOST_AUTO_TEST_CASE(print_sorted_events)
+{
+  binlog::Session session;
+  binlog::SessionWriter writer(session, 512);
+
+  logClock(writer, 100);
+  logClock(writer, 200);
+  logClock(writer, 300);
+  logClock(writer, 250);
+  logClock(writer, 150);
+  logClock(writer, 260);
+
+  logClock(writer, 30'000'000'000 + 100);
+  logClock(writer, 30'000'000'000 + 300);
+  logClock(writer, 30'000'000'000 + 200);
+  logClock(writer, 30'000'000'000 + 150);
+  logClock(writer, 30'000'000'000 + 250);
+  logClock(writer, 30'000'000'000 + 260);
+
+  logClock(writer, 50'000'000'000 + 300);
+  logClock(writer, 40'000'000'000 + 100);
+  logClock(writer, 80'000'000'000 + 250);
+  logClock(writer, 70'000'000'000 + 150);
+  logClock(writer, 60'000'000'000 + 200);
+  logClock(writer, 90'000'000'000 + 260);
+
+  std::stringstream binstream;
+  session.consume(binstream);
+
+  std::stringstream txtstream;
+  printSortedEvents(binstream, txtstream, "%m\n", "");
+
+  const std::vector<std::string> expected{
+    "100", "150", "200", "250", "260", "300",
+    "30000000100", "30000000150", "30000000200",
+    "30000000250", "30000000260", "30000000300",
+    "40000000100", "50000000300", "60000000200",
+    "70000000150", "80000000250", "90000000260",
   };
   BOOST_TEST(streamToLines(txtstream) == expected, boost::test_tools::per_element());
 }

--- a/test/unit/binlog/TestPrinters.cpp
+++ b/test/unit/binlog/TestPrinters.cpp
@@ -1,0 +1,51 @@
+#include <printers.hpp>
+
+#include <binlog/Session.hpp>
+#include <binlog/SessionWriter.hpp>
+#include <binlog/advanced_log_macros.hpp>
+
+#include <boost/test/unit_test.hpp>
+
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace {
+
+std::vector<std::string> streamToLines(std::istream& input)
+{
+  std::vector<std::string> result;
+  std::string line;
+  while (std::getline(input, line))
+  {
+    result.push_back(std::move(line));
+  }
+  return result;
+}
+
+} // namespace
+
+BOOST_AUTO_TEST_SUITE(Printers)
+
+BOOST_AUTO_TEST_CASE(print_events)
+{
+  binlog::Session session;
+  binlog::SessionWriter writer(session, 512);
+
+  BINLOG_INFO_W(writer, "Hello {}", std::string("World"));
+  BINLOG_WARN_W(writer, "foobar {}", 123);
+
+  std::stringstream binstream;
+  session.consume(binstream);
+
+  std::stringstream txtstream;
+  printEvents(binstream, txtstream, "%S %m\n", "");
+
+  const std::vector<std::string> expected{
+    "INFO Hello World",
+    "WARN foobar 123",
+  };
+  BOOST_TEST(streamToLines(txtstream) == expected, boost::test_tools::per_element());
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
The sorting is approximate. It assumes that if event `A` comes before event `B` in the logfile, then event `B` is no more than 60 seconds older than event `A`. This is to allow online sorting of log streams, and memory efficient sorting of large logfiles.

Fixes #6 .