### PR TITLE
Add -s switch to bread to sort events by time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,6 +135,7 @@ add_library(binlog OBJECT
 
 add_executable(bread
   bin/bread.cpp
+  bin/printers.cpp
   $<TARGET_OBJECTS:binlog>
   $<$<CXX_COMPILER_ID:MSVC>:bin/getopt.cpp bin/binaryio.cpp>
 )
@@ -191,6 +192,9 @@ if(Boost_FOUND)
     test/unit/binlog/TestArrayView.cpp
     test/unit/binlog/TestConstCharPtrIsString.cpp
 
+    bin/printers.cpp
+    test/unit/binlog/TestPrinters.cpp
+
     test/unit/binlog/test_utils.cpp
   )
     target_compile_definitions(UnitTest PRIVATE
@@ -201,6 +205,7 @@ if(Boost_FOUND)
     link_boost(UnitTest unit_test_framework)
     target_link_libraries(UnitTest headers)
     target_link_libraries(UnitTest Threads::Threads) # used by: TestQueue, TestSessionWriter, TestCreateSourceAndEvent
+    target_include_directories(UnitTest PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/bin)
 
   add_test(NAME UnitTest COMMAND UnitTest --log_level=test_suite --color_output=true)
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,10 @@ There's a lot of **redundancy** (the severity, the format string, the file path 
 **wasted space** (the timestamp is represented using 29 bytes, where 8 bytes of information would be plenty),
 and **loss of precision** (the originally computed floating point _result_ is lost, only its text representation
 remains). Furthermore, the log was **expensive to produce** (consider the string conversion of each timestamp
-and float value) and **not trivial to parse** using automated tools.
+and float value) and **not trivial to parse** using automated tools. Conventional log solutions also have to
+make a trade-off: either implement synchronous logging (possibly via slow locking) that ensures the
+log events are sorted by creation time, or asynchronous logging (without global locks) that usually
+produces **unsorted output**.
 
 Binlog solves these issues by using _structured binary logs_.
 The static parts (severity, format string, file and line, etc) are saved only once to the logfile.
@@ -38,6 +41,7 @@ without reverting to fragile text processing methods.
 
 _Binary logfiles_ are not human readable, but they can be converted to text using the `bread` program.
 The format of the text log is configurable, independent of the logfile.
+`bread` can also efficiently sort the logs by time, taking advantage of its structured nature.
 For further information, please refer to the [Documentation][].
 
 ## Features
@@ -55,6 +59,7 @@ For further information, please refer to the [Documentation][].
  - Format strings with `{}` placeholders
  - Vertical separation of logs via custom categories
  - Horizontal separation of logs via runtime configurable severities
+ - Sort logs by time while reading
 
 ## Performance
 

--- a/bin/bread.cpp
+++ b/bin/bread.cpp
@@ -1,8 +1,5 @@
 #include "getopt.hpp"
-
-#include <binlog/Entries.hpp> // Event
-#include <binlog/EventStream.hpp>
-#include <binlog/PrettyPrinter.hpp>
+#include "printers.hpp"
 
 #include <fstream>
 #include <iostream>
@@ -19,17 +16,6 @@ std::istream& openFile(const std::string& path, std::ifstream& file)
 
   file.open(path, std::ios_base::in | std::ios_base::binary);
   return file;
-}
-
-void printEvents(std::istream& input, std::ostream& output, const std::string& format, const std::string& dateFormat)
-{
-  binlog::EventStream eventStream(input);
-  binlog::PrettyPrinter pp(format, dateFormat);
-
-  while (const binlog::Event* event = eventStream.nextEvent())
-  {
-    pp.printEvent(output, *event, eventStream.writerProp(), eventStream.clockSync());
-  }
 }
 
 void showHelp()

--- a/bin/bread.cpp
+++ b/bin/bread.cpp
@@ -24,7 +24,7 @@ void showHelp()
     "bread -- convert binary logfiles to human readable text\n"
     "\n"
     "Synopsis:\n"
-    "  bread filename [-f format] [-d date-format]\n"
+    "  bread filename [-f format] [-d date-format] [-s]\n"
     "\n"
     "Examples:\n"
     "  bread logfile.blog"                                 "\n"
@@ -40,6 +40,7 @@ void showHelp()
     "  -h             Show this help\n"
     "  -f             Set a custom format string to write events, see 'Event Format'\n"
     "  -d             Set a custom format string to write timestamps, see 'Date Format'\n"
+    "  -s             Sort events by time\n"
     "\n"
     "Event Format\n"
     "  Log events are transformed to text by substituting placeholders"
@@ -92,9 +93,10 @@ int main(int argc, /*const*/ char* argv[])
   std::string inputPath = "-";
   std::string format = "%S %C [%d] %n %m (%G:%L)\n";
   std::string dateFormat = "%m/%d %H:%M:%S.%N";
+  bool sorted = false;
 
   int opt;
-  while ((opt = getopt(argc, argv, "f:d:h")) != -1)
+  while ((opt = getopt(argc, argv, "f:d:sh")) != -1)
   {
     switch (opt)
     {
@@ -104,6 +106,9 @@ int main(int argc, /*const*/ char* argv[])
       break;
     case 'd':
       dateFormat = optarg;
+      break;
+    case 's':
+      sorted = true;
       break;
     case 'h':
       showHelp();
@@ -132,7 +137,14 @@ int main(int argc, /*const*/ char* argv[])
 
   try
   {
-    printEvents(input, std::cout, format, dateFormat);
+    if (sorted)
+    {
+      printSortedEvents(input, std::cout, format, dateFormat);
+    }
+    else
+    {
+      printEvents(input, std::cout, format, dateFormat);
+    }
   }
   catch (const std::exception& ex)
   {

--- a/bin/printers.cpp
+++ b/bin/printers.cpp
@@ -1,0 +1,19 @@
+#include "printers.hpp"
+
+#include <binlog/Entries.hpp> // Event
+#include <binlog/EventStream.hpp>
+#include <binlog/PrettyPrinter.hpp>
+
+#include <istream>
+#include <ostream>
+
+void printEvents(std::istream& input, std::ostream& output, const std::string& format, const std::string& dateFormat)
+{
+  binlog::EventStream eventStream(input);
+  binlog::PrettyPrinter pp(format, dateFormat);
+
+  while (const binlog::Event* event = eventStream.nextEvent())
+  {
+    pp.printEvent(output, *event, eventStream.writerProp(), eventStream.clockSync());
+  }
+}

--- a/bin/printers.hpp
+++ b/bin/printers.hpp
@@ -1,0 +1,16 @@
+#ifndef BINLOG_BIN_PRINTERS_HPP
+#define BINLOG_BIN_PRINTERS_HPP
+
+#include <iosfwd>
+#include <string>
+
+/**
+ * Print the events in `input` to output, according to
+ * `format` and `dateFormat`.
+ *
+ * @see PrettyPrinter on `format` and `dateFormat`.
+ * @throws std::runtime_error if invalid binlog entry found in `input`.
+ */
+void printEvents(std::istream& input, std::ostream& output, const std::string& format, const std::string& dateFormat);
+
+#endif // BINLOG_BIN_PRINTERS_HPP

--- a/bin/printers.hpp
+++ b/bin/printers.hpp
@@ -13,4 +13,15 @@
  */
 void printEvents(std::istream& input, std::ostream& output, const std::string& format, const std::string& dateFormat);
 
+/**
+ * Print the events in `input` to output, according to
+ * `format` and `dateFormat`, sorted by event clock.
+ *
+ * First buffer every event in `input`, then sort and print them.
+ *
+ * @see PrettyPrinter on `format` and `dateFormat`.
+ * @throws std::runtime_error if invalid binlog entry found in `input`.
+ */
+void printSortedEvents(std::istream& input, std::ostream& output, const std::string& format, const std::string& dateFormat);
+
 #endif // BINLOG_BIN_PRINTERS_HPP

--- a/doc/UserGuide.md
+++ b/doc/UserGuide.md
@@ -184,6 +184,11 @@ The format of the text representation can be customized using command line switc
 
     $ bread -f "%S [%d] %n %m (%G:%L)" -d "%m/%d %H:%M:%S.%N" logfile.blog
 
+The events of the logfile can be sorted by their timestamp using `-s`.
+The complete input is consumed first, then sorted and printed in one go.
+
+    $ bread -s logfile.blog
+
 To customize the output and for further options, see the builtin help:
 
     $ bread -h

--- a/test/unit/binlog/TestPrinters.cpp
+++ b/test/unit/binlog/TestPrinters.cpp
@@ -1,0 +1,51 @@
+#include <printers.hpp>
+
+#include <binlog/Session.hpp>
+#include <binlog/SessionWriter.hpp>
+#include <binlog/advanced_log_macros.hpp>
+
+#include <boost/test/unit_test.hpp>
+
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace {
+
+std::vector<std::string> streamToLines(std::istream& input)
+{
+  std::vector<std::string> result;
+  std::string line;
+  while (std::getline(input, line))
+  {
+    result.push_back(std::move(line));
+  }
+  return result;
+}
+
+} // namespace
+
+BOOST_AUTO_TEST_SUITE(Printers)
+
+BOOST_AUTO_TEST_CASE(print_events)
+{
+  binlog::Session session;
+  binlog::SessionWriter writer(session, 512);
+
+  BINLOG_INFO_W(writer, "Hello {}", std::string("World"));
+  BINLOG_WARN_W(writer, "foobar {}", 123);
+
+  std::stringstream binstream;
+  session.consume(binstream);
+
+  std::stringstream txtstream;
+  printEvents(binstream, txtstream, "%S %m\n", "");
+
+  const std::vector<std::string> expected{
+    "INFO Hello World",
+    "WARN foobar 123",
+  };
+  BOOST_TEST(streamToLines(txtstream) == expected, boost::test_tools::per_element());
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/unit/binlog/TestPrinters.cpp
+++ b/test/unit/binlog/TestPrinters.cpp
@@ -23,6 +23,11 @@ std::vector<std::string> streamToLines(std::istream& input)
   return result;
 }
 
+void logClock(binlog::SessionWriter& writer, std::uint64_t clock)
+{
+  BINLOG_CREATE_SOURCE_AND_EVENT(writer, binlog::Severity::info, main, clock, "{}", clock);
+}
+
 } // namespace
 
 BOOST_AUTO_TEST_SUITE(Printers)
@@ -44,6 +49,33 @@ BOOST_AUTO_TEST_CASE(print_events)
   const std::vector<std::string> expected{
     "INFO Hello World",
     "WARN foobar 123",
+  };
+  BOOST_TEST(streamToLines(txtstream) == expected, boost::test_tools::per_element());
+}
+
+BOOST_AUTO_TEST_CASE(print_sorted_events)
+{
+  binlog::Session session;
+  binlog::SessionWriter writer(session, 512);
+
+  logClock(writer, 1);
+  logClock(writer, 2);
+  logClock(writer, 9);
+  logClock(writer, 7);
+  logClock(writer, 4);
+  logClock(writer, 6);
+  logClock(writer, 5);
+  logClock(writer, 3);
+  logClock(writer, 8);
+
+  std::stringstream binstream;
+  session.consume(binstream);
+
+  std::stringstream txtstream;
+  printSortedEvents(binstream, txtstream, "%m\n", "");
+
+  const std::vector<std::string> expected{
+    "1", "2", "3", "4", "5", "6", "7", "8", "9",
   };
   BOOST_TEST(streamToLines(txtstream) == expected, boost::test_tools::per_element());
 }


### PR DESCRIPTION
The sorting is always correct (c.f: #10), but doesn't work with online logs, and consumes a lot of memory if the input is large. This is a simple and clean approach, that also allows to later introduce an approximate solution, solving the online/large input use-case.

Fixes #6 