### PR TITLE
Attempt to fix race in TestSessionWriter

### DIFF
--- a/test/unit/binlog/TestSessionWriter.cpp
+++ b/test/unit/binlog/TestSessionWriter.cpp
@@ -158,12 +158,13 @@ BOOST_AUTO_TEST_CASE(add_events_from_threads)
   std::atomic<bool> write_done{false};
   std::thread consumer([&session, &out, &write_done]()
   {
-    bool done = false;
-    while (! done)
+    while (! write_done.load())
     {
-      const binlog::Session::ConsumeResult cr = session.consume(out);
-      done = cr.channelsPolled == 0 && write_done.load();
+      session.consume(out);
     }
+
+    // consume events written after last consume but before the loop condition was tested
+    session.consume(out);
   });
 
   threadA.join();


### PR DESCRIPTION
The race is in the test, not in the library code.
The race was not reproducible locally, only once in the CI:

 - consumer consumes, finds no queues (producer threads are not
   scheduled yet)
 - producer threads get scheduled, and complete at once
 - write_done is set
 - consumer checks channelsPolled and write_done, exits
   before the queues are actually flushed