### PR TITLE
Improve bread performance

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,16 @@ if(NOT HAS_CLOCK_GETTIME)
   set(HAS_CLOCK_GETTIME 1)
 endif()
 
+# Interprocedural Optimization (LTO)
+if(POLICY CMP0069)
+  cmake_policy(SET CMP0069 NEW)
+  include(CheckIPOSupported) # fails if policy 69 is not set
+  check_ipo_supported(RESULT BINLOG_HAS_IPO)
+  if(BINLOG_HAS_IPO)
+    message(STATUS "Use interprocedural optimization")
+  endif()
+endif()
+
 #---------------------------
 # clang-tidy
 #---------------------------
@@ -112,6 +122,9 @@ if(BINLOG_USE_CLANG_TIDY)
     if (CLANG_TIDY_EXE)
       message(STATUS "Use clang-tidy: ${CLANG_TIDY_EXE}")
       set(CMAKE_CXX_CLANG_TIDY  "${CLANG_TIDY_EXE}" -warnings-as-errors=*)
+
+      message(STATUS "Disable interprocedural optimization because of clang-tidy")
+      set(BINLOG_HAS_IPO OFF)
     else()
       message(SEND_ERROR "clang-tidy executable not found")
     endif()
@@ -142,6 +155,7 @@ add_library(binlog STATIC
   include/binlog/TextOutputStream.cpp
 )
   target_link_libraries(binlog PUBLIC headers)
+  set_property(TARGET binlog PROPERTY INTERPROCEDURAL_OPTIMIZATION ${BINLOG_HAS_IPO})
 
 #---------------------------
 # bread
@@ -153,6 +167,7 @@ add_executable(bread
   $<$<CXX_COMPILER_ID:MSVC>:bin/getopt.cpp bin/binaryio.cpp>
 )
   target_link_libraries(bread PRIVATE binlog)
+  set_property(TARGET bread  PROPERTY INTERPROCEDURAL_OPTIMIZATION ${BINLOG_HAS_IPO})
 
 #---------------------------
 # brecovery

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,6 +153,7 @@ add_library(binlog STATIC
   include/binlog/PrettyPrinter.cpp
   include/binlog/EntryStream.cpp
   include/binlog/TextOutputStream.cpp
+  include/binlog/detail/OstreamBuffer.cpp
 )
   target_link_libraries(binlog PUBLIC headers)
   set_property(TARGET binlog PROPERTY INTERPROCEDURAL_OPTIMIZATION ${BINLOG_HAS_IPO})
@@ -236,6 +237,7 @@ if(Boost_FOUND)
     test/unit/binlog/TestEntryStream.cpp
     test/unit/binlog/TestTextOutputStream.cpp
     test/unit/binlog/TestEventFilter.cpp
+    test/unit/binlog/detail/TestOstreamBuffer.cpp
 
     bin/printers.cpp
     test/unit/binlog/TestPrinters.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,11 @@ function(link_boost target library)
   endif()
 endfunction()
 
+# do not use -rdynamic, make binaries smaller
+if(POLICY CMP0065)
+  cmake_policy(SET CMP0065 NEW)
+endif()
+
 #---------------------------
 # Build type
 #---------------------------

--- a/include/binlog/PrettyPrinter.cpp
+++ b/include/binlog/PrettyPrinter.cpp
@@ -19,7 +19,12 @@ namespace {
 // or the full path if no path separator (/ or \) found.
 void printFilename(binlog::detail::OstreamBuffer& out, const std::string& path)
 {
-  const std::size_t i = path.find_last_of("/\\", std::string::npos, 2) + 1;
+  std::size_t i = path.size();
+  while (i != 0)
+  {
+    if (path[i-1] == '/' || path[i-1] == '\\') { break; }
+    --i;
+  }
   out.write(path.data() + i, path.size() - i);
 }
 

--- a/include/binlog/PrettyPrinter.hpp
+++ b/include/binlog/PrettyPrinter.hpp
@@ -3,6 +3,7 @@
 
 #include <binlog/Entries.hpp>
 #include <binlog/Time.hpp>
+#include <binlog/detail/OstreamBuffer.hpp>
 
 #include <cstdint>
 #include <iosfwd>
@@ -44,7 +45,7 @@ public:
 
   /**
    * Print `event` using `writerProp` and `clockSync`
-   * to `out`, according the the format specified in the consturctor.
+   * to `ostr`, according to the format specified in the consturctor.
    *
    * If clockSync.clockFrequency is zero,
    * broken down timestamps (%d and %u) are shown
@@ -54,7 +55,7 @@ public:
    * @pre event.source must be valid
    */
   void printEvent(
-    std::ostream& out,
+    std::ostream& ostr,
     const Event& event,
     const WriterProp& writerProp = {},
     const ClockSync& clockSync = {}
@@ -62,20 +63,20 @@ public:
 
 private:
   void printEventField(
-    std::ostream& out,
+    detail::OstreamBuffer& out,
     char spec,
     const Event& event,
     const WriterProp& writerProp,
     const ClockSync& clockSync
   ) const;
 
-  void printEventMessage(std::ostream& out, const Event& event) const;
+  void printEventMessage(detail::OstreamBuffer& out, const Event& event) const;
 
-  void printProducerLocalTime(std::ostream& out, const ClockSync& clockSync, std::uint64_t clockValue) const;
-  void printUTCTime(std::ostream& out, const ClockSync& clockSync, std::uint64_t clockValue) const;
+  void printProducerLocalTime(detail::OstreamBuffer& out, const ClockSync& clockSync, std::uint64_t clockValue) const;
+  void printUTCTime(detail::OstreamBuffer& out, const ClockSync& clockSync, std::uint64_t clockValue) const;
 
-  void printTime(std::ostream& out, BrokenDownTime& bdt, int tzoffset, const char* tzname) const;
-  void printTimeField(std::ostream& out, char spec, BrokenDownTime& bdt, int tzoffset, const char* tzname) const;
+  void printTime(detail::OstreamBuffer& out, BrokenDownTime& bdt, int tzoffset, const char* tzname) const;
+  void printTimeField(detail::OstreamBuffer& out, char spec, BrokenDownTime& bdt, int tzoffset, const char* tzname) const;
 
   std::string _eventFormat;
   std::string _timeFormat;

--- a/include/binlog/ToStringVisitor.cpp
+++ b/include/binlog/ToStringVisitor.cpp
@@ -2,18 +2,15 @@
 
 #include <mserialize/detail/tag_util.hpp> // remove_prefix_before
 
-#include <ios> // boolalpha
 
 namespace binlog {
 
-ToStringVisitor::ToStringVisitor(std::ostream& out)
+ToStringVisitor::ToStringVisitor(detail::OstreamBuffer& out)
   :_state(State::Normal),
    _seqDepth(0),
    _emptyStruct(false),
    _out(out)
-{
-  _out << std::boolalpha;
-}
+{}
 
 // avoid displaying int8_t and uint8_t as a character
 void ToStringVisitor::visit(std::int8_t v)
@@ -103,7 +100,7 @@ void ToStringVisitor::visit(mserialize::Visitor::StructEnd)
   }
   else
   {
-    _out.write(" }", 2);
+    _out << " }";
     leaveSeq();
   }
 }
@@ -131,7 +128,7 @@ void ToStringVisitor::comma()
   }
   else if (_state == State::Seq)
   {
-    _out.write(", ", 2);
+    _out << ", ";
   }
 }
 

--- a/include/binlog/ToStringVisitor.hpp
+++ b/include/binlog/ToStringVisitor.hpp
@@ -1,10 +1,11 @@
 #ifndef BINLOG_TO_STRING_VISITOR_HPP
 #define BINLOG_TO_STRING_VISITOR_HPP
 
+#include <binlog/detail/OstreamBuffer.hpp>
+
 #include <mserialize/Visitor.hpp>
 
 #include <cstdint>
-#include <ostream>
 
 namespace binlog {
 
@@ -17,13 +18,14 @@ namespace binlog {
  * Usage:
  *
  *    std::ostringstream str;
- *    ToStringVisitor visitor(str);
+ *    binlog::detail::OstreamBuffer buf(str);
+ *    ToStringVisitor visitor(buf);
  *    mserialize::visit(tag, visitor, istream);
  */
 class ToStringVisitor
 {
 public:
-  explicit ToStringVisitor(std::ostream& out);
+  explicit ToStringVisitor(detail::OstreamBuffer& out);
 
   // catch all for arithmetic types
   template <typename T>
@@ -70,7 +72,7 @@ private:
   State _state;
   int _seqDepth;
   bool _emptyStruct;
-  std::ostream& _out;
+  detail::OstreamBuffer& _out;
 };
 
 } // namespace binlog

--- a/include/binlog/detail/OstreamBuffer.cpp
+++ b/include/binlog/detail/OstreamBuffer.cpp
@@ -1,0 +1,92 @@
+#include <binlog/detail/OstreamBuffer.hpp>
+
+#include <cassert>
+#include <cinttypes>
+#include <cstdio>
+#include <cstring>
+
+namespace binlog {
+namespace detail {
+
+OstreamBuffer::OstreamBuffer(std::ostream& out)
+  :_out(out),
+   _buf{},
+   _p(_buf.data())
+{}
+
+OstreamBuffer::~OstreamBuffer()
+{
+  flush();
+}
+
+void OstreamBuffer::put(char c)
+{
+  reserve(1);
+  *_p++ = c;
+}
+
+void OstreamBuffer::write(const char* buf, std::size_t size)
+{
+  while (size != 0)
+  {
+    const std::size_t wsize = (std::min)(size, _buf.size());
+    reserve(wsize);
+    memcpy(_p, buf, wsize);
+    _p += wsize;
+    size -= wsize;
+    buf += wsize;
+  }
+}
+
+OstreamBuffer& OstreamBuffer::operator<<(bool b)
+{
+  if (b) { return *this << "true"; }
+           return *this << "false";
+}
+
+OstreamBuffer& OstreamBuffer::operator<<(double v)
+{
+  reserve(64);
+  _p += snprintf(_p, 64, "%g", v);
+  return *this;
+}
+
+OstreamBuffer& OstreamBuffer::operator<<(long double v)
+{
+  reserve(128);
+  _p += snprintf(_p, 128, "%Lg", v);
+  return *this;
+}
+
+void OstreamBuffer::writeSigned(std::int64_t v)
+{
+  // TODO(benedek) perf: use a faster than printf int-to-string solution
+  reserve(32);
+  _p += snprintf(_p, 32, "%" PRId64, v);
+}
+
+void OstreamBuffer::writeUnsigned(std::uint64_t v)
+{
+  // TODO(benedek) perf: use a faster than printf uint-to-string solution
+  reserve(32);
+  _p += snprintf(_p, 32, "%" PRIu64, v);
+}
+
+void OstreamBuffer::reserve(std::size_t n)
+{
+  assert(n <= _buf.size());
+
+  if (std::size_t(_p - _buf.data()) + n > _buf.size())
+  {
+    flush();
+  }
+}
+
+void OstreamBuffer::flush()
+{
+  _out.write(_buf.data(), _p - _buf.data());
+  _p = _buf.data();
+}
+
+} // namespace detail
+} // namespace binlog

--- a/include/binlog/detail/OstreamBuffer.hpp
+++ b/include/binlog/detail/OstreamBuffer.hpp
@@ -1,0 +1,96 @@
+#ifndef BINLOG_DETAIL_OSTREAM_BUFFER_HPP
+#define BINLOG_DETAIL_OSTREAM_BUFFER_HPP
+
+#include <mserialize/string_view.hpp>
+
+#include <array>
+#include <cstdint>
+#include <ostream>
+
+namespace binlog {
+namespace detail {
+
+/**
+ * A faster way to write an ostream.
+ *
+ * Takes an ostream (the underlying device),
+ * and buffers the result of unformatted
+ * and formatted write operations locally.
+ *
+ * Before the local buffer overflows,
+ * flushes it to the underlying device.
+ *
+ * This avoids repeated construction/destruction
+ * of stream sentries.
+ *
+ * The number-to-string operations are
+ * more efficient than the equivalent
+ * ostream formatted operations.
+ */
+class OstreamBuffer
+{
+public:
+  explicit OstreamBuffer(std::ostream& out);
+  ~OstreamBuffer();
+
+  OstreamBuffer(const OstreamBuffer&) = delete;
+  void operator=(const OstreamBuffer&) = delete;
+
+  OstreamBuffer(OstreamBuffer&&) = delete;
+  void operator=(OstreamBuffer&&) = delete;
+
+  void put(char c);
+
+  void write(const char* buf, std::size_t size);
+
+  OstreamBuffer& operator<<(bool);
+  OstreamBuffer& operator<<(char c) { put(c); return *this; }
+
+  OstreamBuffer& operator<<(std::int8_t   v) { writeSigned(v); return *this; }
+  OstreamBuffer& operator<<(std::int16_t  v) { writeSigned(v); return *this; }
+  OstreamBuffer& operator<<(std::int32_t  v) { writeSigned(v); return *this; }
+  OstreamBuffer& operator<<(std::int64_t  v) { writeSigned(v); return *this; }
+  OstreamBuffer& operator<<(std::uint8_t  v) { writeUnsigned(v); return *this; }
+  OstreamBuffer& operator<<(std::uint16_t v) { writeUnsigned(v); return *this; }
+  OstreamBuffer& operator<<(std::uint32_t v) { writeUnsigned(v); return *this; }
+  OstreamBuffer& operator<<(std::uint64_t v) { writeUnsigned(v); return *this; }
+
+  OstreamBuffer& operator<<(double);
+  OstreamBuffer& operator<<(long double);
+
+  OstreamBuffer& operator<<(mserialize::string_view str)
+  {
+    write(str.data(), str.size());
+    return *this;
+  }
+
+  OstreamBuffer& operator<<(const char* str)
+  {
+    return *this << mserialize::string_view(str);
+  }
+
+  template <std::size_t N>
+  OstreamBuffer& operator<<(const char (&array)[N])
+  {
+    write(array, N-1);
+    return *this;
+  }
+
+  void flush();
+
+private:
+  void writeSigned(std::int64_t);
+  void writeUnsigned(std::uint64_t);
+
+  /** @pre n <= _buf.size() */
+  void reserve(std::size_t n);
+
+  std::ostream& _out;
+  std::array<char, 1024> _buf;
+  char* _p;
+};
+
+} // namespace detail
+} // namespace binlog
+
+#endif // BINLOG_DETAIL_OSTREAM_BUFFER_HPP

--- a/test/unit/binlog/TestEventStream.cpp
+++ b/test/unit/binlog/TestEventStream.cpp
@@ -177,9 +177,12 @@ BOOST_AUTO_TEST_CASE(read_event_with_args)
   BOOST_TEST(*e1->source == eventSource);
 
   std::stringstream argStr;
-  binlog::ToStringVisitor visitor(argStr);
-  binlog::Range arguments(e1->arguments);
-  mserialize::visit(e1->source->argumentTags, visitor, arguments);
+  {
+    binlog::detail::OstreamBuffer buf{argStr};
+    binlog::ToStringVisitor visitor(buf);
+    binlog::Range arguments(e1->arguments);
+    mserialize::visit(e1->source->argumentTags, visitor, arguments);
+  }
   BOOST_TEST(argStr.str() == "(789, true, foo)");
 
   const binlog::Event* e2 = eventStream.nextEvent(stream);

--- a/test/unit/binlog/TestToStringVisitor.cpp
+++ b/test/unit/binlog/TestToStringVisitor.cpp
@@ -1,5 +1,7 @@
 #include <binlog/ToStringVisitor.hpp>
 
+#include <binlog/detail/OstreamBuffer.hpp>
+
 #include <mserialize/Visitor.hpp>
 
 #include <boost/mpl/list.hpp>
@@ -21,9 +23,14 @@ struct TestcaseBase
   using V = mserialize::Visitor;
 
   std::ostringstream str;
-  binlog::ToStringVisitor visitor{str};
+  binlog::detail::OstreamBuffer buf{str};
+  binlog::ToStringVisitor visitor{buf};
 
-  std::string result() const { return str.str(); }
+  std::string result()
+  {
+    buf.flush();
+    return str.str();
+  }
 };
 
 } // namespace

--- a/test/unit/binlog/detail/TestOstreamBuffer.cpp
+++ b/test/unit/binlog/detail/TestOstreamBuffer.cpp
@@ -1,0 +1,91 @@
+#include <binlog/detail/OstreamBuffer.hpp>
+
+#include <boost/test/unit_test.hpp>
+
+#include <cstdint>
+#include <sstream>
+
+namespace {
+
+struct TestcaseBase
+{
+  std::ostringstream str;
+  binlog::detail::OstreamBuffer buf{str};
+
+  std::string result()
+  {
+    buf.flush();
+    return str.str();
+  }
+
+  template <typename T>
+  std::string toString(T t)
+  {
+    buf << t;
+    std::string s = result();
+    str.str({}); // clear ostream
+    return s;
+  }
+};
+
+} // namespace
+
+BOOST_AUTO_TEST_SUITE(OstreamBuffer)
+
+BOOST_FIXTURE_TEST_CASE(empty, TestcaseBase)
+{
+  BOOST_TEST(result() == "");
+  buf.write(nullptr, 0);
+  BOOST_TEST(result() == "");
+}
+
+BOOST_FIXTURE_TEST_CASE(put, TestcaseBase)
+{
+  buf.put('a');
+  buf.put('b');
+  buf.put('c');
+  BOOST_TEST(result() == "abc");
+}
+
+BOOST_FIXTURE_TEST_CASE(write, TestcaseBase)
+{
+  buf.write("defgh", 5);
+  BOOST_TEST(result() == "defgh");
+}
+
+BOOST_FIXTURE_TEST_CASE(shift_op, TestcaseBase)
+{
+  BOOST_TEST(toString(true) == "true");
+  BOOST_TEST(toString(false) == "false");
+
+  BOOST_TEST(toString('x') == "x");
+
+  BOOST_TEST(toString<std::int8_t>(23) == "23");
+  BOOST_TEST(toString<std::int16_t>(123) == "123");
+  BOOST_TEST(toString<std::int32_t>(-123) == "-123");
+  BOOST_TEST(toString<std::int64_t>(1357246) == "1357246");
+
+  BOOST_TEST(toString<std::uint8_t>(23) == "23");
+  BOOST_TEST(toString<std::uint16_t>(123) == "123");
+  BOOST_TEST(toString<std::uint32_t>(456) == "456");
+  BOOST_TEST(toString<std::uint64_t>(1357246) == "1357246");
+
+  BOOST_TEST(toString<float>(0.0f) == "0");
+  BOOST_TEST(toString<float>(1.0f) == "1");
+  BOOST_TEST(toString<float>(1.2f) == "1.2");
+  BOOST_TEST(toString<float>(123.456f) == "123.456");
+
+  BOOST_TEST(toString<double>(0.0) == "0");
+  BOOST_TEST(toString<double>(1.0) == "1");
+  BOOST_TEST(toString<double>(-1.2) == "-1.2");
+  BOOST_TEST(toString<double>(123.456) == "123.456");
+
+  BOOST_TEST(toString<long double>(0.0) == "0");
+  BOOST_TEST(toString<long double>(1.0) == "1");
+  BOOST_TEST(toString<long double>(1.2) == "1.2");
+  BOOST_TEST(toString<long double>(-123.456) == "-123.456");
+
+  BOOST_TEST(toString("foobar") == "foobar");
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Low hanging fruits:
 - do not use -rdynamic (incorrect, old cmake behavior)
 - enable interprocedural optimization (LTO)

OstreamBuffer improves performance by avoiding several calls to `std::ostream`.
find_last_of is also slower than a simple loop in the perf test case.

ToDo:
 - faster number to string conversion
 - caching of broken down time objects
 - parallel processing, overlapping I/O