### PR TITLE
Disable MSVC warning in integer_to_hex.hpp

### DIFF
--- a/include/mserialize/detail/integer_to_hex.hpp
+++ b/include/mserialize/detail/integer_to_hex.hpp
@@ -24,6 +24,13 @@ constexpr std::size_t hex_string_size(Integer v)
   return size;
 }
 
+#ifdef _MSC_VER
+  // "unary minus operator applied to unsigned type, result still unsigned"
+  // The referenced line will be never reached if Integer is unsigned.
+  #pragma warning(push)
+  #pragma warning(disable : 4146)
+#endif
+
 template <typename Integer>
 constexpr char* write_integer_as_hex(Integer v, char* end)
 {
@@ -53,6 +60,10 @@ constexpr char* write_integer_as_hex(Integer v, char* end)
 
   return end;
 }
+
+#ifdef _MSC_VER
+  #pragma warning(pop)
+#endif
 
 constexpr char* write_integer_as_hex(bool v, char* end)
 {


### PR DESCRIPTION
In a function template, MSVC complains about `unsigned -v`, but
the referenced line will be never reached if `v` is unsigned,
as `v > 0` will be always true.

Considered alternative: split write_integer_as_hex into two,
and call the correct overload via tag dispatching - but
this requires a lot of code duplication.

Fixes #21 