### PR TITLE
cmake: mark headers as SYSTEM if not the top level project

### DIFF
--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -22,6 +22,11 @@ jobs:
         run: |
           cd Release
           ctest -VV
+      - name: Test Building as Subdir
+        run: |
+          mkdir SubdirTest && cd SubdirTest
+          cmake ../test/cmake/subdir
+          make -j2 VERBOSE=1
 
   build_linux_gcc_asan:
     name: Build on Linux with GCC+ASAN

--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -27,6 +27,13 @@ jobs:
           mkdir SubdirTest && cd SubdirTest
           cmake ../test/cmake/subdir
           make -j2 VERBOSE=1
+      - name: Test Depending on Install
+        run: |
+          make -C Release install DESTDIR=install
+          export CMAKE_PREFIX_PATH=$(pwd)/Release/install/usr/local/lib/cmake
+          mkdir InstallTest && cd InstallTest
+          cmake ../test/cmake/install
+          make -j2 VERBOSE=1
 
   build_linux_gcc_asan:
     name: Build on Linux with GCC+ASAN

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ include(ThreadSanitizer)
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
 
-SET(Boost_USE_STATIC_LIBS OFF)
+set(Boost_USE_STATIC_LIBS OFF)
 if(BINLOG_FORCE_TESTS)
   find_package(Boost 1.64.0 REQUIRED COMPONENTS unit_test_framework filesystem system)
 else()
@@ -138,10 +138,17 @@ endif()
 #---------------------------
 
 add_library(headers INTERFACE)
-  target_include_directories(headers INTERFACE
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include>
-  )
+  if(${CMAKE_PROJECT_NAME} STREQUAL ${PROJECT_NAME})
+    target_include_directories(headers INTERFACE
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+      $<INSTALL_INTERFACE:include>
+    )
+  else()
+    target_include_directories(headers SYSTEM INTERFACE
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+      $<INSTALL_INTERFACE:include>
+    )
+  endif()
   if(CLOCK_GETTIME_IN_LIBRT)
     target_link_libraries(headers INTERFACE -lrt)
   endif()
@@ -157,6 +164,12 @@ add_library(binlog STATIC
 )
   target_link_libraries(binlog PUBLIC headers)
   set_property(TARGET binlog PROPERTY INTERPROCEDURAL_OPTIMIZATION ${BINLOG_HAS_IPO})
+
+# make add_subdirectory usage consistent with find_package
+if(NOT(${CMAKE_PROJECT_NAME} STREQUAL ${PROJECT_NAME}))
+  add_library(binlog::headers ALIAS headers)
+  add_library(binlog::binlog  ALIAS binlog)
+endif()
 
 #---------------------------
 # bread

--- a/test/cmake/headers.cpp
+++ b/test/cmake/headers.cpp
@@ -1,0 +1,3 @@
+#include <binlog/binlog.hpp>
+
+int main() {}

--- a/test/cmake/install/CMakeLists.txt
+++ b/test/cmake/install/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.1)
+project(install_test VERSION 0.1.0 LANGUAGES CXX)
+
+find_package(binlog 0.1.0 REQUIRED)
+
+set(CMAKE_CXX_STANDARD 14)            # -std=c++14
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)         # no gnu++14
+
+add_executable(hello_headers ../headers.cpp)
+  target_link_libraries(hello_headers binlog::headers)
+
+add_executable(hello_lib ../lib.cpp)
+  target_link_libraries(hello_lib binlog::binlog)

--- a/test/cmake/lib.cpp
+++ b/test/cmake/lib.cpp
@@ -1,0 +1,14 @@
+#include <binlog/TextOutputStream.hpp> // requires binlog library to be linked
+#include <binlog/binlog.hpp>
+
+#include <iostream>
+
+int main()
+{
+  BINLOG_INFO("Hello Text Output!");
+
+  binlog::TextOutputStream output(std::cout);
+  binlog::consume(output);
+
+  return 0;
+}

--- a/test/cmake/subdir/CMakeLists.txt
+++ b/test/cmake/subdir/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.1)
+project(subdir_test VERSION 0.1.0 LANGUAGES CXX)
+
+add_subdirectory(../../../ binlog)
+
+set(CMAKE_CXX_STANDARD 14)            # -std=c++14
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)         # no gnu++14
+
+add_executable(hello_headers ../headers.cpp)
+  target_link_libraries(hello_headers binlog::headers)
+
+add_executable(hello_lib ../lib.cpp)
+  target_link_libraries(hello_lib binlog::binlog)


### PR DESCRIPTION
Fixes #28 