### PR TITLE
Make Channel co-owned by Session and SessionWriter

### DIFF
--- a/test/unit/binlog/TestSession.cpp
+++ b/test/unit/binlog/TestSession.cpp
@@ -27,24 +27,24 @@ BOOST_AUTO_TEST_CASE(channel_lifecycle)
   BOOST_TEST(cr.channelsPolled == 0);
   BOOST_TEST(cr.channelsRemoved == 0);
 
-  binlog::Session::Channel& ch1 = session.createChannel(128);
+  std::shared_ptr<binlog::Session::Channel> ch1 = session.createChannel(128);
 
   cr = session.consume(out);
   BOOST_TEST(cr.channelsPolled == 1);
   BOOST_TEST(cr.channelsRemoved == 0);
 
-  binlog::Session::Channel& ch2 = session.createChannel(128);
+  std::shared_ptr<binlog::Session::Channel> ch2 = session.createChannel(128);
 
   cr = session.consume(out);
   BOOST_TEST(cr.channelsPolled == 2);
   BOOST_TEST(cr.channelsRemoved == 0);
 
-  ch1.closed = true;
+  ch1.reset();
   cr = session.consume(out);
   BOOST_TEST(cr.channelsPolled == 2);
   BOOST_TEST(cr.channelsRemoved == 1);
 
-  ch2.closed = true;
+  ch2.reset();
   cr = session.consume(out);
   BOOST_TEST(cr.channelsPolled == 1);
   BOOST_TEST(cr.channelsRemoved == 1);
@@ -57,10 +57,10 @@ BOOST_AUTO_TEST_CASE(channel_lifecycle)
 BOOST_AUTO_TEST_CASE(set_channel_name)
 {
   binlog::Session session;
-  binlog::Session::Channel& ch = session.createChannel(128);
+  std::shared_ptr<binlog::Session::Channel> ch = session.createChannel(128);
 
-  session.setChannelWriterName(ch, "Sio");
-  BOOST_TEST(ch.writerProp.name == "Sio");
+  session.setChannelWriterName(*ch, "Sio");
+  BOOST_TEST(ch->writerProp.name == "Sio");
 }
 
 BOOST_AUTO_TEST_CASE(min_severity)

--- a/test/unit/binlog/TestSessionWriter.cpp
+++ b/test/unit/binlog/TestSessionWriter.cpp
@@ -313,4 +313,18 @@ BOOST_AUTO_TEST_CASE(move_assign)
   BOOST_TEST(getEvents(session, "%n %m") == expectedEvents, boost::test_tools::per_element());
 }
 
+BOOST_AUTO_TEST_CASE(swap_writers_of_different_sessions)
+{
+  binlog::Session sa;
+  binlog::SessionWriter wa(sa, 128);
+
+  binlog::Session sb;
+  binlog::SessionWriter wb(sb, 128);
+
+  std::swap(wa, wb);
+  // at this point, wa references a channel of sb,
+  // but sb is destructed first. ASAN will detect
+  // if wa accesses a destructed channel.
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Session stores shared_ptr of Channels,
shared with the respective SessionWriters.

The Channel is closed if only the Session owns it,
checked by shared_ptr::use_count.

Stability of Channel references is provided by the shared_ptr,
storing them in a list is no longer necessary -
it is replaced with a vector, that is faster to iterate.

Motivation: use-after-free if SessionWriter is destroyed
later than the Session it references. See contrived
test swap_writers_of_different_sessions that reproduces the issue.

Fixes #40 