### PR TITLE
Do not call OutputStream::write(nullptr, 0)

### DIFF
--- a/include/mserialize/detail/Serializer.hpp
+++ b/include/mserialize/detail/Serializer.hpp
@@ -142,9 +142,15 @@ private:
     const Sequence& s, std::uint32_t size, OutputStream& ostream
   )
   {
-    const char* data = reinterpret_cast<const char*>(sequence_data(s));
-    const size_t serialized_size = sizeof(sequence_data_t<const Sequence>) * size;
-    ostream.write(data, std::streamsize(serialized_size));
+    // Avoid passing nullptr `data` to write, that ends up calling memcpy
+    // (e.g: if OutputStream is QueueWriter) as it is undefined behavior
+    // C11 7.24.1 String function conventions p2
+    if (size)
+    {
+      const char* data = reinterpret_cast<const char*>(sequence_data(s));
+      const size_t serialized_size = sizeof(sequence_data_t<const Sequence>) * size;
+      ostream.write(data, std::streamsize(serialized_size));
+    }
   }
 
   static std::size_t sizeof_elems(

--- a/test/integration/LoggingContainers.cpp
+++ b/test/integration/LoggingContainers.cpp
@@ -36,6 +36,9 @@ int main()
   BINLOG_INFO("More sequence containers: {} {} {}", deq, list, vb);
   // Outputs: More sequence containers: [1, 2, 3] [4, 5, 6] [true, false, true]
 
+  BINLOG_INFO("Empty containers: {} {}", std::vector<int>{}, std::list<bool>{});
+  // Outputs: Empty containers: [] []
+
   //[associative
   std::set<int> set{4,8,15,16,23,42};
   std::map<char, std::string> map{{'a', "alpha"}, {'b', "beta"}};


### PR DESCRIPTION
This unfortunate change adds an extra branch to the hot path
where batch copyable containers (including strings) are logged.

If needed later, the logic can be special cased for std::string
without the additional branch, as std::string::data never
returns nullptr.

Fixes #48 .