### PR TITLE
Adopt to "new" Google Benchmark interface

### DIFF
--- a/test/perf/PerftestQueue.cpp
+++ b/test/perf/PerftestQueue.cpp
@@ -82,7 +82,7 @@ void BM_queueWrite(benchmark::State& state)
   g_done = true;
   reader.join();
 
-  state.SetBytesProcessed(std::int64_t(totalWriteSize));
+  state.SetBytesProcessed(totalWriteSize);
   state.counters["FailedWrite"] = double(failedWriteCount);
 }
 


### PR DESCRIPTION
The argument of SetBytesProcessed was changed from
int64_t to size_t, by the Google Benchmark commit
7a767012 "Adopt new benchmark timing internals"
in 2015.