### PR TITLE
Fix overflow in ticksToNanoseconds

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -4,10 +4,13 @@
 # std::runtime_error is not nothrow copy constructible (cert-err60-cpp)
 # Rule aliases are not useful (hicpp)
 # llvm-header-guard derives the macro name from the absolute path sometimes
+# sizeof(T*) is prohibited by bugprone-sizeof-expression
+# modernize-use-trailing-return-type is nonsense
 
 Checks: "\
   *,
   -fuchsia-*,\
+  -bugprone-sizeof-expression,\
   -cppcoreguidelines-avoid-c-arrays,\
   -cppcoreguidelines-avoid-magic-numbers,\
   -cppcoreguidelines-macro-usage,\
@@ -19,13 +22,17 @@ Checks: "\
   -hicpp-*,\
   -cert-err58-cpp,\
   -cert-err60-cpp,\
+  -readability-convert-member-functions-to-static,\
   -readability-magic-numbers,\
   -readability-named-parameter,\
   -readability-uppercase-literal-suffix,\
   -misc-non-private-member-variables-in-classes,\
   -modernize-avoid-c-arrays,\
   -modernize-use-auto,\
+  -modernize-use-nodiscard,\
   -modernize-return-braced-init-list,\
+  -modernize-unary-static-assert,\
+  -modernize-use-trailing-return-type,\
   -llvm-header-guard,\
   -google-runtime-references"
 

--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -171,6 +171,6 @@ jobs:
           cmake --build Release --config Release -j2
       - name: Test
         run: |
-          $Env:path += ";${env:BOOST_ROOT}\lib"
+          $Env:path += ";${env:BOOST_ROOT_1_72_0}\lib"
           cd Release
           ctest -VV -C Release

--- a/test/integration/IntegrationTest.cpp
+++ b/test/integration/IntegrationTest.cpp
@@ -149,7 +149,7 @@ BOOST_AUTO_TEST_CASE(DateFormat)
 
   bread.wait();
 
-  const std::vector<std::string> expected{"2019-12-02T13:37:38.262735011Z Hello"};
+  const std::vector<std::string> expected{"2019-12-02T13:38:33.602967233Z Hello"};
 
   compareVectors(expected, actual);
 }

--- a/test/unit/binlog/TestTime.cpp
+++ b/test/unit/binlog/TestTime.cpp
@@ -77,6 +77,14 @@ BOOST_AUTO_TEST_CASE(ticks_to_ns)
   BOOST_TEST(binlog::ticksToNanoseconds(3'000'000'000, 2) == std::chrono::nanoseconds{0});
   BOOST_TEST(binlog::ticksToNanoseconds(3'000'000'000, 3) == std::chrono::nanoseconds{1});
   BOOST_TEST(binlog::ticksToNanoseconds(3'000'000'000, 31) == std::chrono::nanoseconds{10});
+
+  // make sure it does not overflow
+  BOOST_TEST(binlog::ticksToNanoseconds(1'000'000'000, 31'534'085'395) == std::chrono::nanoseconds{31534085395});
+  BOOST_TEST(binlog::ticksToNanoseconds(3'000'000'000, 30'000'000'000) == std::chrono::seconds{10});
+
+  // int64_t(double(x)) != x
+  BOOST_TEST(binlog::ticksToNanoseconds(1'000'000'000, 9007199254740993) == std::chrono::nanoseconds{9007199254740993});
+  BOOST_TEST(binlog::ticksToNanoseconds(1'000'000'000, 1575293913602967233) == std::chrono::nanoseconds{1575293913602967233});
 }
 
 BOOST_AUTO_TEST_CASE(clock_to_ns)


### PR DESCRIPTION
ticks * std::nano::den overflows even for ticks representing
a 32 seconds duration at 1GHz. Use an arithmetic trick
to compute a*b/c without overflowing.
Microbenchmark suggests that this approach isn't measurable slower,
despite that it must take more cycles. Pipelining effect
in the benchmark is suspected.

IntegrationTest: the expected value was wrong.

Considered alternatives:

   - Use 128 bit integers to do the arithmetic, if available.
     This includes GCC, Clang and MSVC above 2019, on x64,
     excludes x32 and possibly other platforms, requires conditional compilation.

   - Use double arithmetic, at the price of limited precision.