### PR TITLE
Make MSERIALIZE_MAKE_STRUCT_TAG support C-style array members

### DIFF
--- a/include/mserialize/make_struct_tag.hpp
+++ b/include/mserialize/make_struct_tag.hpp
@@ -90,7 +90,7 @@ namespace mserialize {
  */
 
 template <typename T, typename Field>
-auto serializable_member_type(Field T::*field) -> Field;
+auto serializable_member_type(Field T::*field) -> Field&;
 
 template <typename T, typename Ret>
 auto serializable_member_type(Ret (T::*getter)() const) -> Ret;

--- a/test/unit/mserialize/tag.cpp
+++ b/test/unit/mserialize/tag.cpp
@@ -135,6 +135,17 @@ MSERIALIZE_MAKE_STRUCT_TAG(Foo, alpha, bravo, charlie)
 
 static_assert(mserialize::tag<Foo>() == "{Foo`alpha'i`bravo'[c`charlie'<0f>}", "");
 
+struct Bar
+{
+  int a[1];
+  bool b[2][3];
+  char c[4][5][6];
+};
+
+MSERIALIZE_MAKE_STRUCT_TAG(Bar, a, b, c)
+
+static_assert(mserialize::tag<Bar>() == "{Bar`a'[i`b'[[y`c'[[[c}", "");
+
 // test MSERIALIZE_MAKE_TEMPLATE_TAG
 
 template <typename A, typename B>


### PR DESCRIPTION
serializable_member_type is used to disambiguate fields/getters,
by encoding the member type in the return type.
While C arrays cannot be returned by value, they can be returned by
reference.

Fixes #71 