### PR TITLE
Fix IntegerToHex bugs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -252,6 +252,7 @@ if(Boost_FOUND)
     test/unit/mserialize/tag.cpp
     test/unit/mserialize/visit.cpp
     test/unit/mserialize/documentation.cpp
+    test/unit/mserialize/inttohex.cpp
 
     test/unit/binlog/TestEventStream.cpp
     test/unit/binlog/TestTime.cpp

--- a/include/mserialize/detail/Visit.hpp
+++ b/include/mserialize/detail/Visit.hpp
@@ -22,7 +22,7 @@ public:
   std::enable_if_t<std::is_integral<Integer>::value>
   visit(Integer v)
   {
-    _p = write_integer_as_hex(v, _p) - 1;
+    _p = write_integer_as_hex(v, &_buffer[19]);
   }
 
   template <typename T>
@@ -31,14 +31,15 @@ public:
 
   string_view value() const
   {
-    return string_view(_p+1, std::size_t(_buffer + 18 - _p));
+    return string_view(_p, std::size_t(_buffer + 19 - _p));
   }
 
   string_view delimited_value(char prefix, char postfix)
   {
+    char* begin = _p - 1;
+    *begin = prefix;
     _buffer[19] = postfix;
-    *_p = prefix;
-    return string_view(_p, std::size_t(_buffer + 20 - _p));
+    return string_view(begin, std::size_t(_buffer + 20 - begin));
   }
 };
 

--- a/test/unit/mserialize/inttohex.cpp
+++ b/test/unit/mserialize/inttohex.cpp
@@ -1,0 +1,72 @@
+#include <mserialize/visit.hpp>
+
+#include <boost/test/unit_test.hpp>
+
+#include <cstdint>
+#include <ios>
+#include <limits>
+#include <sstream>
+#include <string>
+
+namespace {
+
+std::string hexvalue(int i)
+{
+  std::ostringstream ostream;
+  ostream << std::hex << std::uppercase << i;
+  return ostream.str();
+}
+
+} // namespace
+
+BOOST_AUTO_TEST_SUITE(MserializeInttohex)
+
+//BOOST_AUTO_TEST_CASE(empty)
+//{
+//  mserialize::detail::IntegerToHex hex;
+//  BOOST_TEST(hex.value() == "");
+//  BOOST_TEST(hex.delimited_value('x', 'y') == "xy");
+//}
+
+BOOST_AUTO_TEST_CASE(convert_positive_int)
+{
+  for (int i = 0; i < 512; ++i)
+  {
+    mserialize::detail::IntegerToHex hex;
+    hex.visit(i);
+    BOOST_TEST(hex.value() == hexvalue(i));
+    BOOST_TEST(hex.delimited_value('!', '?') == '!' + hexvalue(i) + '?');
+  }
+}
+
+BOOST_AUTO_TEST_CASE(convert_min)
+{
+  mserialize::detail::IntegerToHex hex;
+  hex.visit(std::numeric_limits<std::int64_t>::min());
+  BOOST_TEST(hex.value() == "-8000000000000000");
+  BOOST_TEST(hex.delimited_value('!', '?') == "!-8000000000000000?");
+}
+
+BOOST_AUTO_TEST_CASE(convert_max)
+{
+  mserialize::detail::IntegerToHex hex;
+  hex.visit(std::numeric_limits<std::uint64_t>::max());
+  BOOST_TEST(hex.value() == "FFFFFFFFFFFFFFFF");
+  BOOST_TEST(hex.delimited_value('!', '?') == "!FFFFFFFFFFFFFFFF?");
+}
+
+//BOOST_AUTO_TEST_CASE(multi_visit)
+//{
+//  mserialize::detail::IntegerToHex hex;
+//
+//  for (int i = 0; i <= 256; ++i)
+//  {
+//    hex.visit(i);
+//  }
+//
+//  // only the last visited integer value is kept:
+//  BOOST_TEST(hex.value() == "100");
+//  BOOST_TEST(hex.delimited_value('x', 'y') == "x100y");
+//}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/unit/mserialize/inttohex.cpp
+++ b/test/unit/mserialize/inttohex.cpp
@@ -21,12 +21,12 @@ std::string hexvalue(int i)
 
 BOOST_AUTO_TEST_SUITE(MserializeInttohex)
 
-//BOOST_AUTO_TEST_CASE(empty)
-//{
-//  mserialize::detail::IntegerToHex hex;
-//  BOOST_TEST(hex.value() == "");
-//  BOOST_TEST(hex.delimited_value('x', 'y') == "xy");
-//}
+BOOST_AUTO_TEST_CASE(empty)
+{
+  mserialize::detail::IntegerToHex hex;
+  BOOST_TEST(hex.value() == "");
+  BOOST_TEST(hex.delimited_value('x', 'y') == "xy");
+}
 
 BOOST_AUTO_TEST_CASE(convert_positive_int)
 {
@@ -55,18 +55,18 @@ BOOST_AUTO_TEST_CASE(convert_max)
   BOOST_TEST(hex.delimited_value('!', '?') == "!FFFFFFFFFFFFFFFF?");
 }
 
-//BOOST_AUTO_TEST_CASE(multi_visit)
-//{
-//  mserialize::detail::IntegerToHex hex;
-//
-//  for (int i = 0; i <= 256; ++i)
-//  {
-//    hex.visit(i);
-//  }
-//
-//  // only the last visited integer value is kept:
-//  BOOST_TEST(hex.value() == "100");
-//  BOOST_TEST(hex.delimited_value('x', 'y') == "x100y");
-//}
+BOOST_AUTO_TEST_CASE(multi_visit)
+{
+  mserialize::detail::IntegerToHex hex;
+
+  for (int i = 0; i <= 256; ++i)
+  {
+    hex.visit(i);
+  }
+
+  // only the last visited integer value is kept:
+  BOOST_TEST(hex.value() == "100");
+  BOOST_TEST(hex.delimited_value('x', 'y') == "x100y");
+}
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
On repeated visit, only the last value is kept (instead of overflow)
Without visit, value() remains empty (instead of corrupt).

Bug found by @spektrof using clang libFuzzer.