### PR TITLE
Avoid INT_MIN / -1 arithmetic exception in ticksToNanoseconds

### DIFF
--- a/include/binlog/PrettyPrinter.cpp
+++ b/include/binlog/PrettyPrinter.cpp
@@ -181,7 +181,7 @@ void PrettyPrinter::printProducerLocalTime(detail::OstreamBuffer& out, const Clo
 {
   // TODO(benedek) perf: cache bdt, update instead of complete recompute
 
-  if (clockSync.clockFrequency != 0)
+  if (std::int64_t(clockSync.clockFrequency) > 0)
   {
     BrokenDownTime bdt{};
     const std::chrono::nanoseconds sinceEpoch = clockToNsSinceEpoch(clockSync, clockValue);
@@ -199,7 +199,7 @@ void PrettyPrinter::printUTCTime(detail::OstreamBuffer& out, const ClockSync& cl
 {
   // TODO(benedek) perf: cache bdt, update instead of complete recompute
 
-  if (clockSync.clockFrequency != 0)
+  if (std::int64_t(clockSync.clockFrequency) > 0)
   {
     BrokenDownTime bdt{};
     const std::chrono::nanoseconds sinceEpoch = clockToNsSinceEpoch(clockSync, clockValue);

--- a/include/binlog/PrettyPrinter.hpp
+++ b/include/binlog/PrettyPrinter.hpp
@@ -47,7 +47,7 @@ public:
    * Print `event` using `writerProp` and `clockSync`
    * to `ostr`, according to the format specified in the consturctor.
    *
-   * If clockSync.clockFrequency is zero,
+   * If clockSync.clockFrequency is not positive after casting to int64_t,
    * broken down timestamps (%d and %u) are shown
    * as: "no_clock_sync?", as there's not enough context to
    * render them. The raw clock value remains accessible via %r.

--- a/include/binlog/Time.hpp
+++ b/include/binlog/Time.hpp
@@ -29,7 +29,7 @@ struct BrokenDownTime : std::tm
  *    theoretical result = 1 + 1/3 nanoseconds
  *    result = 1 nanoseconds
  *
- * @pre frequency != 0
+ * @pre int64_t(frequency) > 0
  */
 std::chrono::nanoseconds ticksToNanoseconds(std::uint64_t frequency, std::int64_t ticks);
 

--- a/test/unit/binlog/TestPrettyPrinter.cpp
+++ b/test/unit/binlog/TestPrettyPrinter.cpp
@@ -94,6 +94,16 @@ BOOST_FIXTURE_TEST_CASE(empty_clock_sync, TestcaseBase)
   BOOST_TEST(print(pp) == "no_clock_sync? no_clock_sync? 1569939329");
 }
 
+BOOST_FIXTURE_TEST_CASE(negative_clock_sync_freq, TestcaseBase)
+{
+  binlog::PrettyPrinter pp("%d %u %r", "");
+
+  clockSync = binlog::ClockSync{0, std::uint64_t(-1), 0, 0, {}};
+  event = binlog::Event{&eventSource, 0x8000000000000000, event.arguments};
+
+  BOOST_TEST(print(pp) == "no_clock_sync? no_clock_sync? 9223372036854775808");
+}
+
 BOOST_FIXTURE_TEST_CASE(filename, TestcaseBase)
 {
   binlog::PrettyPrinter pp("%G", "");


### PR DESCRIPTION
By requiring clock frequency to be positive
after casting to int64_t.

Bug found by @spektrof using clang libFuzzer.
