### PR TITLE
Throw in visit_arithmetic if tag is invalid

### DIFF
--- a/include/mserialize/detail/Visit.hpp
+++ b/include/mserialize/detail/Visit.hpp
@@ -69,6 +69,7 @@ void visit_arithmetic(char tag, Visitor& visitor, InputStream& istream)
   case 'f': float f;       mserialize::deserialize(f, istream); visitor.visit(f); break;
   case 'd': double d;      mserialize::deserialize(d, istream); visitor.visit(d); break;
   case 'D': long double D; mserialize::deserialize(D, istream); visitor.visit(D); break;
+  default: throw std::runtime_error(std::string("Invalid arithmetic tag: ") + tag); break;
   }
 }
 

--- a/include/mserialize/visit.hpp
+++ b/include/mserialize/visit.hpp
@@ -24,6 +24,7 @@ namespace mserialize {
  * @throws std::exception if reading of `istream` fails.
  * @throws std::runtime_error if tag is too deeply nested,
  *   to prevent stack overflow.
+ * @throws std::runtime_error if tag is syntactically invalid
  */
 template <typename Visitor, typename InputStream>
 void visit(string_view tag, Visitor& visitor, InputStream& istream)

--- a/test/unit/mserialize/visit.cpp
+++ b/test/unit/mserialize/visit.cpp
@@ -172,6 +172,15 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(arithmetic, T, arithmetic_types)
   }
 }
 
+BOOST_AUTO_TEST_CASE(invalid_arithmetic)
+{
+  CountingVisitor visitor;
+  std::stringstream stream;
+  mserialize::serialize(std::uint64_t(1), stream);
+
+  BOOST_CHECK_THROW(mserialize::visit("X", visitor, stream), std::runtime_error);
+}
+
 BOOST_AUTO_TEST_CASE(empty_vector_of_int)
 {
   const std::vector<int> in;


### PR DESCRIPTION
This is to avoid bread DoS by specifying a sequence
of invalid arithmetic value as an argument tag (e.g: "[X"),
combined with a huge sequence size (e.g: uint32_t(-1)),
that would trigger a huge number of visitations without
actually consuming the input.

Bug was found by @spektrof using clang libFuzzer.
