### PR TITLE
Do not allow 0 tag outside of a variant

### DIFF
--- a/include/mserialize/detail/Visit.hpp
+++ b/include/mserialize/detail/Visit.hpp
@@ -148,7 +148,14 @@ void visit_variant(const string_view full_tag, string_view tag, Visitor& visitor
 
   visitor.visit(mserialize::Visitor::VariantBegin{discriminator, option_tag});
 
-  visit_impl(full_tag, option_tag, visitor, istream, max_recursion);
+  if (option_tag == "0")
+  {
+    visitor.visit(mserialize::Visitor::Null{});
+  }
+  else
+  {
+    visit_impl(full_tag, option_tag, visitor, istream, max_recursion);
+  }
 
   visitor.visit(mserialize::Visitor::VariantEnd{});
 }
@@ -270,9 +277,6 @@ void visit_impl(const string_view full_tag, string_view tag, Visitor& visitor, I
     break;
   case '/':
     visit_enum(tag, visitor, istream);
-    break;
-  case '0':
-    visitor.visit(mserialize::Visitor::Null{});
     break;
   default:
     visit_arithmetic(tag.front(), visitor, istream);

--- a/test/unit/mserialize/visit.cpp
+++ b/test/unit/mserialize/visit.cpp
@@ -541,4 +541,11 @@ BOOST_AUTO_TEST_CASE(deeply_nested_variant_tag)
   }
 }
 
+BOOST_AUTO_TEST_CASE(no_freestanding_null)
+{
+  CountingVisitor visitor;
+  std::stringstream stream;
+  BOOST_CHECK_THROW(mserialize::visit("0", visitor, stream), std::runtime_error);
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This is to prevent cases like [0 combined with
a huge sequece size, that can DoS bread without
actually providing a huge input.

The tag <0> is not affected as the variant requires
reading one byte (the discriminator) from the input.

Bug was found by @spektrof using clang libFuzzer.
