### PR TITLE
Visit singular sequence elems only once

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -253,6 +253,7 @@ if(Boost_FOUND)
     test/unit/mserialize/visit.cpp
     test/unit/mserialize/documentation.cpp
     test/unit/mserialize/inttohex.cpp
+    test/unit/mserialize/singular.cpp
 
     test/unit/binlog/TestEventStream.cpp
     test/unit/binlog/TestTime.cpp

--- a/doc/Mserialize.md
+++ b/doc/Mserialize.md
@@ -368,6 +368,9 @@ Library design tends to be arguable. Some decisions need to be explained.
       visitor.visit(mserialize::Visitor::FieldEnd      );
 
       visitor.visit(mserialize::Visitor::Enum          );
+
+      visitor.visit(mserialize::Visitor::RepeatBegin   );
+      visitor.visit(mserialize::Visitor::RepeatEnd     );
     };
 
 # References

--- a/include/binlog/ToStringVisitor.cpp
+++ b/include/binlog/ToStringVisitor.cpp
@@ -132,6 +132,16 @@ void ToStringVisitor::comma()
   }
 }
 
+void ToStringVisitor::visit(mserialize::Visitor::RepeatBegin) {}
+
+void ToStringVisitor::visit(mserialize::Visitor::RepeatEnd re)
+{
+  if (re.size > 1)
+  {
+    _out << " ... <repeats " << re.size << " times>";
+  }
+}
+
 void ToStringVisitor::enterSeq()
 {
   _state = State::SeqBegin;

--- a/include/binlog/ToStringVisitor.hpp
+++ b/include/binlog/ToStringVisitor.hpp
@@ -58,6 +58,9 @@ public:
   void visit(mserialize::Visitor::FieldBegin);
   void visit(mserialize::Visitor::FieldEnd);
 
+  void visit(mserialize::Visitor::RepeatBegin);
+  void visit(mserialize::Visitor::RepeatEnd);
+
 private:
   void comma();
 

--- a/include/mserialize/Visitor.hpp
+++ b/include/mserialize/Visitor.hpp
@@ -84,6 +84,20 @@ struct Visitor
     string_view value;      /**< Hexadecimal value of the enumerator */
   };
 
+  // Repeat - same value repeats `size` times
+
+  struct RepeatBegin
+  {
+    std::size_t size{}; /**< Number of time the next visted value repeats */
+    string_view tag;    /**< Type tag of the repeating value */
+  };
+
+  struct RepeatEnd
+  {
+    std::size_t size{}; /**< Number of time the previous visted value repeats */
+    string_view tag;    /**< Type tag of the repeating value */
+  };
+
   // visitor methods - to be implemented by derived type
 
   virtual void visit(bool          ) = 0;
@@ -118,6 +132,9 @@ struct Visitor
   virtual void visit(FieldEnd      ) = 0;
 
   virtual void visit(Enum          ) = 0;
+
+  virtual void visit(RepeatBegin   ) = 0;
+  virtual void visit(RepeatEnd     ) = 0;
 };
 
 } // namespace mserialize

--- a/include/mserialize/Visitor.hpp
+++ b/include/mserialize/Visitor.hpp
@@ -88,14 +88,14 @@ struct Visitor
 
   struct RepeatBegin
   {
-    std::size_t size{}; /**< Number of time the next visted value repeats */
-    string_view tag;    /**< Type tag of the repeating value */
+    std::uint32_t size{}; /**< Number of time the next visted value repeats */
+    string_view tag;      /**< Type tag of the repeating value */
   };
 
   struct RepeatEnd
   {
-    std::size_t size{}; /**< Number of time the previous visted value repeats */
-    string_view tag;    /**< Type tag of the repeating value */
+    std::uint32_t size{}; /**< Number of time the previous visted value repeats */
+    string_view tag;      /**< Type tag of the repeating value */
   };
 
   // visitor methods - to be implemented by derived type

--- a/include/mserialize/detail/Singular.hpp
+++ b/include/mserialize/detail/Singular.hpp
@@ -1,0 +1,71 @@
+#ifndef MSERIALIZE_DETAIL_SINGULAR_HPP
+#define MSERIALIZE_DETAIL_SINGULAR_HPP
+
+#include <mserialize/detail/tag_util.hpp>
+
+namespace mserialize {
+namespace detail {
+
+inline bool singular_impl(string_view, string_view, int);
+
+inline bool singular_tuple(string_view full_tag, string_view tag, int max_recursion)
+{
+  tag.remove_prefix(1); // drop (
+  tag.remove_suffix(1); // drop )
+  for (string_view elem_tag = tag_pop(tag); ! elem_tag.empty(); elem_tag = tag_pop(tag))
+  {
+    if (! singular_impl(full_tag, elem_tag, max_recursion)) { return false; }
+  }
+  return true;
+}
+
+inline bool singular_struct(string_view full_tag, string_view tag, int max_recursion)
+{
+  tag.remove_suffix(1); // drop }
+
+  string_view intro = remove_prefix_before(tag, '`');
+
+  if (tag.empty())
+  {
+    // perhaps a recursive struct?
+    const std::size_t intro_pos = full_tag.find(intro);
+    tag = string_view(full_tag.data() + intro_pos, full_tag.size() - intro_pos);
+    tag = tag_pop(tag);
+    tag.remove_prefix(intro.size());
+    tag.remove_suffix(1);
+    // if tag is not empty at this point, this is a recursive struct: non-singular
+    return tag.empty();
+  }
+
+  while (! tag.empty())
+  {
+    tag_pop_label(tag); // field_name
+    const string_view field_tag = tag_pop(tag);
+
+    if (! singular_impl(full_tag, field_tag, max_recursion)) { return false; }
+  }
+  return true;
+
+}
+
+inline bool singular_impl(string_view full_tag, string_view tag, int max_recursion)
+{
+  if (max_recursion == 0) { throw std::runtime_error("Recursion limit exceeded while visiting tag: " + full_tag.to_string()); }
+
+  if (tag.empty()) { return true; }
+
+  switch (tag.front())
+  {
+  case '(':
+    return singular_tuple(full_tag, tag, max_recursion - 1);
+  case '{':
+    return singular_struct(full_tag, tag, max_recursion - 1);
+  }
+
+  return false;
+}
+
+} // namespace detail
+} // namespace mserialize
+
+#endif // MSERIALIZE_DETAIL_SINGULAR_HPP

--- a/include/mserialize/singular.hpp
+++ b/include/mserialize/singular.hpp
@@ -1,0 +1,37 @@
+#ifndef MSERIALIZE_SINGULAR_HPP
+#define MSERIALIZE_SINGULAR_HPP
+
+#include <mserialize/string_view.hpp>
+
+#include <mserialize/detail/Singular.hpp>
+
+namespace mserialize {
+
+/**
+ * A tag of type T is singular, if objects of type T
+ * have only a single valid value.
+ *
+ * Objects of singular types are always serialized
+ * using 0 bytes.
+ *
+ * `full_tag` is needed to tell apart empty structs
+ * and references of recursive structs.
+ * Recursive structs are always considered non-singular.
+ * While the infinitely recursive "{E`e'{E}}" could be considered
+ * to be singular, it cannot be serialized or visited,
+ * therefore it doesn't matter.
+ *
+ * @pre `tag` must be a valid type tag, e.g:
+ *   a tag returned by mserialize::tag<T>().
+ * @throws std::runtime_error if tag is too deeply nested,
+ *   to prevent stack overflow.
+ * @return true if `tag` is singular
+ */
+inline bool singular(string_view full_tag, string_view tag, int max_recursion = 2048)
+{
+  return detail::singular_impl(full_tag, tag, max_recursion);
+}
+
+} // namespace mserialize
+
+#endif // MSERIALIZE_SINGULAR_HPP

--- a/test/unit/binlog/TestToStringVisitor.cpp
+++ b/test/unit/binlog/TestToStringVisitor.cpp
@@ -261,4 +261,22 @@ BOOST_FIXTURE_TEST_CASE(empty_field_name, TestcaseBase)
   BOOST_TEST(result() == "BoundedInt{ 1024 }");
 }
 
+BOOST_FIXTURE_TEST_CASE(repeat_once, TestcaseBase)
+{
+  visitor.visit(V::RepeatBegin{1, "i"});
+  visitor.visit(int(1));
+  visitor.visit(V::RepeatEnd{1, "i"});
+
+  BOOST_TEST(result() == "1");
+}
+
+BOOST_FIXTURE_TEST_CASE(repeat_more, TestcaseBase)
+{
+  visitor.visit(V::RepeatBegin{9, "i"});
+  visitor.visit(int(1));
+  visitor.visit(V::RepeatEnd{9, "i"});
+
+  BOOST_TEST(result() == "1 ... <repeats 9 times>");
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/unit/mserialize/singular.cpp
+++ b/test/unit/mserialize/singular.cpp
@@ -1,0 +1,70 @@
+#include <mserialize/singular.hpp>
+
+#include <boost/test/unit_test.hpp>
+
+namespace {
+
+bool non_recursive_singular(mserialize::string_view tag)
+{
+  return mserialize::singular(tag, tag);
+}
+
+} // namespace
+
+BOOST_AUTO_TEST_SUITE(MserializeSingular)
+
+BOOST_AUTO_TEST_CASE(singular)
+{
+  BOOST_TEST(non_recursive_singular("()") == true);
+  BOOST_TEST(non_recursive_singular("(())") == true);
+  BOOST_TEST(non_recursive_singular("((()))") == true);
+
+  BOOST_TEST(non_recursive_singular("{Empty}") == true);
+  BOOST_TEST(non_recursive_singular("{Empty`x'()}") == true);
+  BOOST_TEST(non_recursive_singular("{Empty`x'(())}") == true);
+  BOOST_TEST(non_recursive_singular("{Empty`x'{Nil}}") == true);
+  BOOST_TEST(non_recursive_singular("{Empty`x'{Nil}`y'{Nul}}") == true);
+
+}
+
+BOOST_AUTO_TEST_CASE(not_singular)
+{
+  BOOST_TEST(non_recursive_singular("y") == false);
+  BOOST_TEST(non_recursive_singular("c") == false);
+
+  BOOST_TEST(non_recursive_singular("b") == false);
+  BOOST_TEST(non_recursive_singular("s") == false);
+  BOOST_TEST(non_recursive_singular("i") == false);
+  BOOST_TEST(non_recursive_singular("l") == false);
+
+  BOOST_TEST(non_recursive_singular("B") == false);
+  BOOST_TEST(non_recursive_singular("S") == false);
+  BOOST_TEST(non_recursive_singular("I") == false);
+  BOOST_TEST(non_recursive_singular("L") == false);
+
+  BOOST_TEST(non_recursive_singular("f") == false);
+  BOOST_TEST(non_recursive_singular("d") == false);
+  BOOST_TEST(non_recursive_singular("D") == false);
+
+  BOOST_TEST(non_recursive_singular("[i") == false);
+  BOOST_TEST(non_recursive_singular("[f") == false);
+  BOOST_TEST(non_recursive_singular("[y") == false);
+
+  BOOST_TEST(non_recursive_singular("(i)") == false);
+
+  BOOST_TEST(non_recursive_singular("<>") == false);
+  BOOST_TEST(non_recursive_singular("<i>") == false);
+  BOOST_TEST(non_recursive_singular("<()>") == false);
+
+  BOOST_TEST(non_recursive_singular("/i`E'\\") == false);
+
+  BOOST_TEST(non_recursive_singular("{List`n'<0List>}") == false);
+}
+
+BOOST_AUTO_TEST_CASE(recursive)
+{
+  BOOST_TEST(mserialize::singular("{Empty`x'{Empty}}", "{Empty}") == false); // infinite recursion
+  BOOST_TEST(mserialize::singular("{R,`r'[{R}}", "{R}") == false);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/unit/mserialize/visit.cpp
+++ b/test/unit/mserialize/visit.cpp
@@ -82,6 +82,9 @@ public:
   void visit(mserialize::Visitor::FieldBegin fb)    { _str << fb.name << '(' << fb.tag << "): "; }
   void visit(mserialize::Visitor::FieldEnd)         { _str << ", "; }
 
+  void visit(mserialize::Visitor::RepeatBegin rb) { _str << "RB(" << rb.size << ',' << rb.tag << ")( ";}
+  void visit(mserialize::Visitor::RepeatEnd)      { _str << ") "; }
+
   std::string value() const { return _str.str(); }
 };
 

--- a/test/unit/mserialize/visit.cpp
+++ b/test/unit/mserialize/visit.cpp
@@ -541,6 +541,13 @@ BOOST_AUTO_TEST_CASE(deeply_nested_variant_tag)
   }
 }
 
+BOOST_AUTO_TEST_CASE(infinite_recursive_struct)
+{
+  CountingVisitor visitor;
+  std::stringstream stream;
+  BOOST_CHECK_THROW(mserialize::visit("{R`r'{R}}", visitor, stream), std::runtime_error);
+}
+
 BOOST_AUTO_TEST_CASE(no_freestanding_null)
 {
   CountingVisitor visitor;


### PR DESCRIPTION
To prevent tags like `[()` and `[{Empty}` combined
with a large sequence size generate huge output with little input.

Bug was found by @spektrof using clang libFuzzer.