### PR TITLE
Fix singular: remove first label of recursive/empty struct

### DIFF
--- a/include/mserialize/detail/Singular.hpp
+++ b/include/mserialize/detail/Singular.hpp
@@ -33,6 +33,7 @@ inline bool singular_struct(string_view full_tag, string_view tag, int max_recur
     tag = tag_pop(tag);
     tag.remove_prefix(intro.size());
     tag.remove_suffix(1);
+    tag_pop_label(tag);
     // if tag is not empty at this point, this is a recursive struct: non-singular
     return tag.empty();
   }
@@ -44,8 +45,8 @@ inline bool singular_struct(string_view full_tag, string_view tag, int max_recur
 
     if (! singular_impl(full_tag, field_tag, max_recursion)) { return false; }
   }
-  return true;
 
+  return true;
 }
 
 inline bool singular_impl(string_view full_tag, string_view tag, int max_recursion)

--- a/include/mserialize/detail/Visit.hpp
+++ b/include/mserialize/detail/Visit.hpp
@@ -227,6 +227,7 @@ void visit_struct(const string_view full_tag, string_view tag, Visitor& visitor,
  *
  * @pre tag.front() == / and tag.back() == \
  * @pre the underlying type must be an integer tag
+ * @throws std::runtime_error if syntax is invalid
  */
 template <typename Visitor, typename InputStream>
 void visit_enum(string_view tag, Visitor& visitor, InputStream& istream)
@@ -234,7 +235,7 @@ void visit_enum(string_view tag, Visitor& visitor, InputStream& istream)
   tag.remove_prefix(1); // drop slash
   tag.remove_suffix(1); // drop backslash
 
-  if (tag.empty()) { return; }
+  if (tag.empty()) { throw std::runtime_error("Invalid enum tag: '" + tag.to_string() + "'"); }
 
   // convert the discriminator to hex
   const char underlying_type_tag = tag[0];

--- a/test/unit/mserialize/singular.cpp
+++ b/test/unit/mserialize/singular.cpp
@@ -67,4 +67,10 @@ BOOST_AUTO_TEST_CASE(recursive)
   BOOST_TEST(mserialize::singular("{R,`r'[{R}}", "{R}") == false);
 }
 
+BOOST_AUTO_TEST_CASE(corrupt_but_singular)
+{
+  BOOST_TEST(mserialize::singular("[{1t0", "{1t") == true);
+  BOOST_TEST(mserialize::singular("(", "(") == true);
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Bug was found by @spektrof using clang libFuzzer.