### PR TITLE
Fix resolve_recursive_tag bug

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -254,6 +254,7 @@ if(Boost_FOUND)
     test/unit/mserialize/documentation.cpp
     test/unit/mserialize/inttohex.cpp
     test/unit/mserialize/singular.cpp
+    test/unit/mserialize/tag_util.cpp
 
     test/unit/binlog/TestEventStream.cpp
     test/unit/binlog/TestTime.cpp

--- a/include/mserialize/detail/Singular.hpp
+++ b/include/mserialize/detail/Singular.hpp
@@ -28,11 +28,8 @@ inline bool singular_struct(string_view full_tag, string_view tag, int max_recur
   if (tag.empty())
   {
     // perhaps a recursive struct?
-    const std::size_t intro_pos = full_tag.find(intro);
-    tag = string_view(full_tag.data() + intro_pos, full_tag.size() - intro_pos);
-    tag = tag_pop(tag);
-    tag.remove_prefix(intro.size());
-    tag.remove_suffix(1);
+    tag = resolve_recursive_tag(full_tag, intro);
+    // drop the name of the first field, if any
     tag_pop_label(tag);
     // if tag is not empty at this point, this is a recursive struct: non-singular
     return tag.empty();

--- a/include/mserialize/detail/Visit.hpp
+++ b/include/mserialize/detail/Visit.hpp
@@ -194,11 +194,7 @@ void visit_struct(const string_view full_tag, string_view tag, Visitor& visitor,
   if (tag.empty())
   {
     // perhaps a recursive struct?
-    const std::size_t intro_pos = full_tag.find(intro);
-    tag = string_view(full_tag.data() + intro_pos, full_tag.size() - intro_pos);
-    tag = tag_pop(tag);
-    tag.remove_prefix(intro.size());
-    tag.remove_suffix(1);
+    tag = resolve_recursive_tag(full_tag, intro);
   }
 
   intro.remove_prefix(1); // drop {

--- a/include/mserialize/detail/tag_util.hpp
+++ b/include/mserialize/detail/tag_util.hpp
@@ -123,6 +123,33 @@ inline string_view tag_pop_arithmetic(string_view& tags)
   return arithmetic_tag;
 }
 
+/**
+ * Find the definition (sequence of label-tag pairs) of the
+ * given struct `intro` in `full_tag`.
+ *
+ * This is useful as recursive structs can be referenced
+ * without giving the full definition, e.g:
+ *
+ *     full_tag = "{N`n'<0{N}>}"
+ *     intro = "{N"
+ *     resolve_recursive_tag(full_tag, intro) == "`n'<0{N}>"
+ *
+ * If `intro` references an empty struct, returns an empty string.
+ *
+ * @param full_tag the complete type tag
+ * @param intro the {Foo part of a struct tag
+ * @return sequence of field label-tag pairs
+ */
+inline string_view resolve_recursive_tag(string_view full_tag, string_view intro)
+{
+  const std::size_t intro_pos = full_tag.find(intro);
+  string_view tag(full_tag.data() + intro_pos, full_tag.size() - intro_pos);
+  tag = tag_pop(tag);
+  tag.remove_prefix(intro.size());
+  tag.remove_suffix(1); // drop closing curly
+  return tag;
+}
+
 } // namespace detail
 } // namespace mserialize
 

--- a/include/mserialize/detail/tag_util.hpp
+++ b/include/mserialize/detail/tag_util.hpp
@@ -142,12 +142,22 @@ inline string_view tag_pop_arithmetic(string_view& tags)
  */
 inline string_view resolve_recursive_tag(string_view full_tag, string_view intro)
 {
-  const std::size_t intro_pos = full_tag.find(intro);
-  string_view tag(full_tag.data() + intro_pos, full_tag.size() - intro_pos);
-  tag = tag_pop(tag);
-  tag.remove_prefix(intro.size());
-  tag.remove_suffix(1); // drop closing curly
-  return tag;
+  while (! full_tag.empty())
+  {
+    const std::size_t intro_pos = full_tag.find(intro);
+    full_tag.remove_prefix(intro_pos);
+    full_tag.remove_prefix(intro.size());
+    if (full_tag.empty()) { break; }
+    if (full_tag.front() == '}') { break; } // empty struct
+    if (full_tag.front() == '`') // definition found
+    {
+      const std::size_t size = size_between_balanced(full_tag, '{', '}');
+      return string_view{full_tag.data(), size - 1};
+    }
+    // else: spurious find, e.g: found {FooBar for {Foo
+  }
+
+  return {};
 }
 
 } // namespace detail

--- a/test/unit/mserialize/singular.cpp
+++ b/test/unit/mserialize/singular.cpp
@@ -64,7 +64,7 @@ BOOST_AUTO_TEST_CASE(not_singular)
 BOOST_AUTO_TEST_CASE(recursive)
 {
   BOOST_TEST(mserialize::singular("{Empty`x'{Empty}}", "{Empty}") == false); // infinite recursion
-  BOOST_TEST(mserialize::singular("{R,`r'[{R}}", "{R}") == false);
+  BOOST_TEST(mserialize::singular("{R`r'[{R}}", "{R}") == false);
 }
 
 BOOST_AUTO_TEST_CASE(corrupt_but_singular)

--- a/test/unit/mserialize/tag_util.cpp
+++ b/test/unit/mserialize/tag_util.cpp
@@ -1,0 +1,18 @@
+#include <mserialize/detail/tag_util.hpp>
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_SUITE(MserializeTagUtil)
+
+BOOST_AUTO_TEST_CASE(resolve_recursive_tag)
+{
+  using mserialize::detail::resolve_recursive_tag;
+  BOOST_TEST(resolve_recursive_tag("", "") == "");
+  BOOST_TEST(resolve_recursive_tag("{A}", "{A") == "");
+  BOOST_TEST(resolve_recursive_tag("{A`f'i}", "{A") == "`f'i");
+  BOOST_TEST(resolve_recursive_tag("(ii{A`f'i}II)", "{A") == "`f'i");
+  BOOST_TEST(resolve_recursive_tag("{A`n'<0{A}>}", "{A") == "`n'<0{A}>");
+  BOOST_TEST(resolve_recursive_tag("{AA`f'{A}}", "{A") == "");
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/unit/mserialize/visit.cpp
+++ b/test/unit/mserialize/visit.cpp
@@ -597,4 +597,15 @@ BOOST_AUTO_TEST_CASE(seq_of_empty_struct)
   BOOST_TEST(visitor.value() == 18);
 }
 
+BOOST_AUTO_TEST_CASE(empty_prefix_of_containing_struct)
+{
+  const std::string tag = "{FooBar`f'{Foo}}";
+  ToString visitor;
+  std::stringstream stream;
+  stream.exceptions(std::ios_base::failbit);
+
+  mserialize::visit(tag, visitor, stream);
+  BOOST_TEST(visitor.value() == "StB(FooBar,`f'{Foo}) { f({Foo}): StB(Foo,) { } , } ");
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Given the {FooBar`f'{Foo}} full tag
(i.e: a struct FooBar with a single Foo field named f, Foo is empty),
resolve_recursive_tag should correctly resolve {Foo intro to
an empty label-tag sequence, instead of finding the containing type,
that happes to also start with {Foo.

Similar bug was found by @spektrof using clang libFuzzer.