### PR TITLE
Fix resolve_recursive_tag bug 2

### DIFF
--- a/include/binlog/EntryStream.cpp
+++ b/include/binlog/EntryStream.cpp
@@ -32,7 +32,7 @@ Range IstreamEntryStream::nextEntryPayload()
   if (! _input) // payload is truncated
   {
     rewind(std::streamsize(sizeof(size)) + _input.gcount());
-    throw std::runtime_error("Failed to entry payload from istream, only got "
+    throw std::runtime_error("Failed to read entry payload from istream, only got "
       + std::to_string(_input.gcount()) + " bytes, expected " + std::to_string(size));
   }
 

--- a/include/mserialize/detail/tag_util.hpp
+++ b/include/mserialize/detail/tag_util.hpp
@@ -142,6 +142,8 @@ inline string_view tag_pop_arithmetic(string_view& tags)
  */
 inline string_view resolve_recursive_tag(string_view full_tag, string_view intro)
 {
+  if (intro.empty()) { return {}; }
+
   while (! full_tag.empty())
   {
     const std::size_t intro_pos = full_tag.find(intro);

--- a/test/unit/mserialize/tag_util.cpp
+++ b/test/unit/mserialize/tag_util.cpp
@@ -8,6 +8,7 @@ BOOST_AUTO_TEST_CASE(resolve_recursive_tag)
 {
   using mserialize::detail::resolve_recursive_tag;
   BOOST_TEST(resolve_recursive_tag("", "") == "");
+  BOOST_TEST(resolve_recursive_tag("{", "") == "");
   BOOST_TEST(resolve_recursive_tag("{A}", "{A") == "");
   BOOST_TEST(resolve_recursive_tag("{A`f'i}", "{A") == "`f'i");
   BOOST_TEST(resolve_recursive_tag("(ii{A`f'i}II)", "{A") == "`f'i");


### PR DESCRIPTION
Avoid infinite loop if intro is empty.
Considered alternative: on the call sites, make sure intro is not empty,
e.g: by getting intro before dropping the closing curly.
The chosen solution generates more instructions,
but also safer and easier to use.

Bug found by @spektrof using clang libFuzzer.