### PR TITLE
Do not use vector iterator after pop_back

### DIFF
--- a/include/binlog/Session.hpp
+++ b/include/binlog/Session.hpp
@@ -8,7 +8,6 @@
 #include <binlog/detail/QueueReader.hpp>
 #include <binlog/detail/VectorOutputStream.hpp>
 
-#include <algorithm> // move
 #include <atomic>
 #include <cstdint>
 #include <deque>
@@ -375,8 +374,7 @@ Session::ConsumeResult Session::consume(OutputStream& out)
     if (isClosed)
     {
       // queue is empty and closed, remove it
-      std::move(it+1, _channels.end(), it);
-      _channels.pop_back();
+      it = _channels.erase(it);
       result.channelsRemoved++;
     }
     else


### PR DESCRIPTION
If `_channels.size() == 1`, after the removal of the
last element, `it` appears to point to the same address
as the end iterator, but according to the standard,
it is really invalid, and shouldn't be used.

Fixes #88
