### PR TITLE
Avoid not-helpful -Wtype-limits on GCC 10.2

### DIFF
--- a/include/mserialize/cx_string.hpp
+++ b/include/mserialize/cx_string.hpp
@@ -33,10 +33,18 @@ public:
   explicit constexpr cx_string(const char* str)
     :_data{0}
   {
+    #if defined(__GNUC__) and not defined(__clang__)
+      // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=96742
+      #pragma GCC diagnostic push
+      #pragma GCC diagnostic ignored "-Wtype-limits"
+    #endif
     for (std::size_t i = 0; i < N; ++i)
     {
       _data[i] = str[i];
     }
+    #if defined(__GNUC__) and not defined(__clang__)
+      #pragma GCC diagnostic pop
+    #endif
   }
 
   /**

--- a/include/mserialize/detail/integer_to_hex.hpp
+++ b/include/mserialize/detail/integer_to_hex.hpp
@@ -19,7 +19,15 @@ constexpr std::size_t hex_string_size(Integer v)
   }
   else
   {
+    #if defined(__GNUC__) and not defined(__clang__)
+      // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=96742
+      #pragma GCC diagnostic push
+      #pragma GCC diagnostic ignored "-Wtype-limits"
+    #endif
     for (; std::int64_t(v) < 0; v /= 16) { ++size; }
+    #if defined(__GNUC__) and not defined(__clang__)
+      #pragma GCC diagnostic pop
+    #endif
   }
   return size;
 }


### PR DESCRIPTION
Fix these warnings on GCC 10.2:

```
binlog/include/mserialize/cx_string.hpp:36:31: error: comparison of unsigned expression in ‘< 0’ is always false [-Werror=type-limits]
   36 |     for (std::size_t i = 0; i < N; ++i)
      |                             ~~^~~
```

```
binlog/include/mserialize/detail/integer_to_hex.hpp:22:28: error: comparison is always false due to limited range of data type [-Werror=type-limits]
   22 |     for (; std::int64_t(v) < 0; v /= 16) { ++size; }
      |                 ~~~~~~~~~~~^~~
```

https://gcc.gnu.org/bugzilla/show_bug.cgi?id=96742
Fixes #93
