### PR TITLE
Allow noexcept getters in C++17

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+Builds/
 Debug/
 Release/
 Sanitized/

--- a/include/mserialize/StructSerializer.hpp
+++ b/include/mserialize/StructSerializer.hpp
@@ -42,6 +42,11 @@ auto serializable_member(Field T::*field) -> decltype(field);
 template <typename T, typename Ret>
 auto serializable_member(Ret (T::*getter)() const) -> decltype(getter);
 
+#if __cplusplus >= 201703L
+template <typename T, typename Ret>
+auto serializable_member(Ret (T::*getter)() const noexcept) -> decltype(getter);
+#endif
+
 /**
  * Serialize the given members of a custom type `T`.
  *
@@ -112,6 +117,14 @@ private:
     mserialize::serialize((t.*getter)(), ostream);
   }
 
+#if __cplusplus >= 201703L
+  template <typename Field, typename OutputStream>
+  static void serialize_member(const T& t, Field (T::*getter)() const noexcept, OutputStream& ostream)
+  {
+    mserialize::serialize((t.*getter)(), ostream);
+  }
+#endif
+
   template <typename Field>
   static std::size_t serialized_size_member(const T& t, Field T::*field)
   {
@@ -123,6 +136,14 @@ private:
   {
     return mserialize::serialized_size((t.*getter)());
   }
+
+#if __cplusplus >= 201703L
+  template <typename Field>
+  static std::size_t serialized_size_member(const T& t, Field (T::*getter)() const noexcept)
+  {
+    return mserialize::serialized_size((t.*getter)());
+  }
+#endif
 };
 
 } // namespace mserialize

--- a/test/unit/mserialize/roundtrip.cpp
+++ b/test/unit/mserialize/roundtrip.cpp
@@ -564,7 +564,7 @@ struct Vehicle
   std::string _name;
   std::unique_ptr<Person> _owner;
 
-  int age() const { return _age; }
+  int age() const noexcept { return _age; }
   int age(const int i) { return _age = i; }
 
   std::string name() const { return _name; }


### PR DESCRIPTION
Since C++17, noexcept is part of the function type,
therefore it requires separate overloads to make template metaprograms
work. Before C++17, those overloads result in ambiguity,
therefore must be only conditionally defined.
