### PR TITLE
Avoid recursion in remove_prefix_before

### DIFF
--- a/include/mserialize/detail/tag_util.hpp
+++ b/include/mserialize/detail/tag_util.hpp
@@ -60,24 +60,37 @@ inline string_view remove_prefix_before(string_view& s, char c)
 /** @returns the size of the first tag in `tags` */
 inline std::size_t tag_first_size(string_view tags)
 {
-  if (tags.empty()) { return 0; }
-
-  switch (tags.front())
+  std::size_t result = 0;
+  for (char c : tags)
   {
-  case '[':
-    tags.remove_prefix(1);
-    return 1 + tag_first_size(tags);
-  case '(':
-    return size_between_balanced(tags, '(', ')');
-  case '<':
-    return size_between_balanced(tags, '<', '>');
-  case '{':
-    return size_between_balanced(tags, '{', '}');
-  case '/':
-    return size_between_balanced(tags, '/', '\\');
+    if (c != '[') { break; }
+    ++result;
+  }
+  tags.remove_prefix(result);
+
+  if (! tags.empty())
+  {
+    switch (tags.front())
+    {
+    case '(':
+      result += size_between_balanced(tags, '(', ')');
+      break;
+    case '<':
+      result += size_between_balanced(tags, '<', '>');
+      break;
+    case '{':
+      result += size_between_balanced(tags, '{', '}');
+      break;
+    case '/':
+      result += size_between_balanced(tags, '/', '\\');
+      break;
+    default:
+      result += 1; // assume arithmetic
+      break;
+    }
   }
 
-  return 1; // assume arithmetic
+  return result;
 }
 
 /** Remove and return the first tag in the concatenated `tags` */

--- a/test/unit/mserialize/tag_util.cpp
+++ b/test/unit/mserialize/tag_util.cpp
@@ -4,6 +4,15 @@
 
 BOOST_AUTO_TEST_SUITE(MserializeTagUtil)
 
+BOOST_AUTO_TEST_CASE(tag_first_size_large_input)
+{
+  std::vector<char> buffer(1'000'001, '[');
+  buffer.back() = 'i';
+
+  const mserialize::string_view tag(buffer.data(), buffer.size());
+  BOOST_TEST(buffer.size() == mserialize::detail::tag_first_size(tag));
+}
+
 BOOST_AUTO_TEST_CASE(resolve_recursive_tag)
 {
   using mserialize::detail::resolve_recursive_tag;


### PR DESCRIPTION
GCC in optimized mode removed the recursion,
but the attached test fails in -O0 mode
with the previous implementation.
